### PR TITLE
interaction between bucket & raindrop, storing number of correctly/incorrectly answered questions, updating home page

### DIFF
--- a/client/src/pages/WaterGame/WaterGame.tsx
+++ b/client/src/pages/WaterGame/WaterGame.tsx
@@ -1,11 +1,17 @@
 /*
 WaterGame Page
 
-This module defines the WaterGame page, which manages the different screens 
-(start, tutorial, game, end) and handles navigation between them. It uses 
-React state to track the current screen and renders the appropriate content 
-based on that state. The component also includes navigation functionality to 
-return to the home page or move between screens using buttons and a back arrow.
+This module defines the WaterGame page, which manages the different screens
+(start, tutorial, game, end) and handles navigation between them. It uses
+React state to track the current screen and renders the appropriate content
+based on that state.
+
+The game presents the player with a series of water-related multiple choice
+questions. Raindrop answers fall from the top of the screen and the player
+must move a bucket left and right using the arrow keys to catch the correct
+answer. The game tracks correct and incorrect answers and displays the results
+on the end screen, where the player's score is pushed to the server to update
+the water resource level.
 */
 
 import { useState, useEffect, useRef, useCallback } from "react";

--- a/client/src/pages/WaterGame/WaterGame.tsx
+++ b/client/src/pages/WaterGame/WaterGame.tsx
@@ -97,10 +97,9 @@ export const WaterGame = () => {
 
   // Resets game state and transitions to the game screen
   const startGame = () => {
-    if (questions.length === 0) {
-      return;
-    }
-    const answers = questionToRaindropAnswers(questions[0]);
+    if (questions.length === 0) return;
+
+    const answers = shuffleArray(questionToRaindropAnswers(questions[0])); // shuffle here too
     setRaindrops([]);
     answerQueueRef.current = answers;
     nextRaindropId.current = 0;
@@ -210,12 +209,6 @@ export const WaterGame = () => {
     return () => clearInterval(interval);
   }, [screen, handleAnswer, moveToNextQuestion]);
 
-  useEffect(() => {
-    console.log("correctCount:", correctCount);
-    console.log("incorrectCount:", incorrectCount);
-    console.log("current question index:", currentQuestionIndex);
-  }, [correctCount, incorrectCount, currentQuestionIndex]);
-
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>{error}</div>;
 
@@ -278,14 +271,6 @@ export const WaterGame = () => {
               {questions[currentQuestionIndex]?.text}
             </p>
           </span>
-          <button
-            onClick={() => {
-              setScreen("end");
-            }}
-            style={{ position: "absolute", right: "16px", top: "16px" }}
-          >
-            End Game
-          </button>
           {raindrops.map((drop) => (
             <Raindrop
               id={drop.id}
@@ -310,7 +295,7 @@ export const WaterGame = () => {
           <Popup
             variant="water"
             screen="end"
-            header="Time's Up"
+            header="Game Over"
             buttonText="Go Back to Home"
             onClick={async () => {
               try {
@@ -327,7 +312,7 @@ export const WaterGame = () => {
             textList={[
               `Number of correctly answered questions: ${correctCount}`,
               `Number of incorrectly answered questions: ${incorrectCount}`,
-              `Total number of points earned: ${correctCount}`,
+              `Total number of points earned: ${Math.ceil((correctCount / questions.length) * 100)}`,
             ]}
           />
         </div>

--- a/client/src/pages/WaterGame/WaterGame.tsx
+++ b/client/src/pages/WaterGame/WaterGame.tsx
@@ -19,6 +19,7 @@ import { useNavigate } from "react-router-dom";
 
 import { useWaterGameQuestions } from "./hooks/useWaterGameQuestions";
 import { pushGameResults } from "../ServerCalls/ServerCalls";
+import { checkCollision } from "./collision";
 
 import { questionToRaindropAnswers, shuffleArray } from "./utils";
 import { Popup } from "../../components/Popup";
@@ -46,6 +47,7 @@ export const WaterGame = () => {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const gameScreenRef = useRef<HTMLDivElement>(null);
+  const isPausedRef = useRef(false);
 
   const [raindrops, setRaindrops] = useState<RaindropData[]>([]);
   const nextRaindropId = useRef(0);
@@ -116,6 +118,25 @@ export const WaterGame = () => {
     setScreen("game");
   };
 
+  // Pauses the game when the tab is hidden and resumes when the tab is visible
+  useEffect(() => {
+    if (screen !== "game") return;
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        // Tab is hidden - intervals will be cleared by their own cleanup
+        // Store that we were paused
+        isPausedRef.current = true;
+      } else {
+        isPausedRef.current = false;
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [screen]);
+
   // Pulls the next answer from the queue and spawns a raindrop at a random
   // horizontal position along the top of the container
   const spawnRaindrop = useCallback(() => {
@@ -153,7 +174,10 @@ export const WaterGame = () => {
   useEffect(() => {
     if (screen !== "game") return;
 
-    const interval = setInterval(spawnRaindrop, SPAWN_INTERVAL_MS);
+    const interval = setInterval(() => {
+      if (isPausedRef.current) return;
+      spawnRaindrop();
+    }, SPAWN_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [screen, spawnRaindrop]);
 
@@ -172,8 +196,6 @@ export const WaterGame = () => {
     setRaindrops([]);
   }, [currentQuestionIndex, questions]);
 
-  // Moves all raindrops downward on each tick and removes any that have
-  // fallen past the bottom of the game screen
   // Moves all raindrops downward on each tick, checks for bucket collision,
   // and removes any that have fallen past the bottom of the game screen
   useEffect(() => {
@@ -184,6 +206,7 @@ export const WaterGame = () => {
     const bucketTop = gameScreenRef.current.offsetHeight - BUCKET_HEIGHT;
 
     const interval = setInterval(() => {
+      if (isPausedRef.current) return;
       setRaindrops((prev) =>
         prev
           .map((drop) => ({
@@ -191,14 +214,7 @@ export const WaterGame = () => {
             y: drop.y + RAINDROP_FALL_SPEED,
           }))
           .filter((drop) => {
-            const raindropRight = drop.x + RAINDROP_WIDTH;
-            const bucketRight = bucketXRef.current + BUCKET_WIDTH; // use ref
-
-            const horizontalOverlap =
-              drop.x < bucketRight && raindropRight > bucketXRef.current;
-            const verticalOverlap = drop.y + RAINDROP_HEIGHT >= bucketTop;
-
-            if (horizontalOverlap && verticalOverlap) {
+            if (checkCollision(drop.x, drop.y, bucketXRef.current, bucketTop)) {
               if (!caughtRaindropIds.current.has(drop.id)) {
                 caughtRaindropIds.current.add(drop.id);
                 handleAnswer(drop.isCorrect);
@@ -210,7 +226,7 @@ export const WaterGame = () => {
             return drop.y < floorY;
           }),
       );
-    }, 16); // bucketX removed from dependencies
+    }, 16);
 
     return () => clearInterval(interval);
   }, [screen, handleAnswer, moveToNextQuestion]);

--- a/client/src/pages/WaterGame/WaterGame.tsx
+++ b/client/src/pages/WaterGame/WaterGame.tsx
@@ -12,7 +12,9 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useWaterGameQuestions } from "./hooks/useWaterGameQuestions";
-import { questionToRaindropAnswers } from "./utils";
+import { pushGameResults } from "../ServerCalls/ServerCalls";
+
+import { questionToRaindropAnswers, shuffleArray } from "./utils";
 import { Popup } from "../../components/Popup";
 import Bucket from "./components/Bucket";
 import { Raindrop } from "./components/Raindrop";
@@ -23,6 +25,7 @@ import {
   RAINDROP_WIDTH,
   SPAWN_INTERVAL_MS,
   BUCKET_WIDTH,
+  BUCKET_HEIGHT,
 } from "./constants";
 
 import styles from "./WaterGame.module.css";
@@ -33,14 +36,34 @@ export const WaterGame = () => {
   );
   const navigate = useNavigate();
   const [bucketX, setBucketX] = useState(0);
+  const bucketXRef = useRef(bucketX);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const gameScreenRef = useRef<HTMLDivElement>(null);
 
   const [raindrops, setRaindrops] = useState<RaindropData[]>([]);
   const nextRaindropId = useRef(0);
+  const caughtRaindropIds = useRef<Set<number>>(new Set());
+
   const answerQueueRef = useRef<RaindropAnswer[]>([]);
   const { questions, isLoading, error } = useWaterGameQuestions();
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+
+  const [correctCount, setCorrectCount] = useState(0);
+  const [incorrectCount, setIncorrectCount] = useState(0);
+
+  const handleAnswer = useCallback((isCorrect: boolean) => {
+    if (isCorrect) {
+      setCorrectCount((prev) => prev + 1);
+    } else {
+      setIncorrectCount((prev) => prev + 1);
+    }
+  }, []);
+
+  // Keep the ref in sync with the state
+  useEffect(() => {
+    bucketXRef.current = bucketX;
+  }, [bucketX]);
 
   // Sets the bucket's initial horizontal position to the center of the container
   // when the game screen mounts
@@ -77,12 +100,14 @@ export const WaterGame = () => {
     if (questions.length === 0) {
       return;
     }
-    console.log(questions);
     const answers = questionToRaindropAnswers(questions[0]);
     setRaindrops([]);
     answerQueueRef.current = answers;
     nextRaindropId.current = 0;
     setCurrentQuestionIndex(0);
+    setCorrectCount(0);
+    setIncorrectCount(0);
+    caughtRaindropIds.current = new Set();
     setScreen("game");
   };
 
@@ -91,9 +116,15 @@ export const WaterGame = () => {
   const spawnRaindrop = useCallback(() => {
     if (!containerRef.current) return;
 
-    const queue = answerQueueRef.current;
-    if (queue.length === 0) return;
+    // Refill queue with shuffled choices if empty
+    if (answerQueueRef.current.length === 0) {
+      if (questions.length === 0) return;
+      answerQueueRef.current = shuffleArray(
+        questionToRaindropAnswers(questions[currentQuestionIndex]),
+      );
+    }
 
+    const queue = answerQueueRef.current;
     const nextAnswer = queue.shift()!;
     const containerWidth = containerRef.current.offsetWidth;
 
@@ -111,7 +142,7 @@ export const WaterGame = () => {
         isCorrect: nextAnswer.isCorrect,
       },
     ]);
-  }, []);
+  }, [currentQuestionIndex, questions]);
 
   // Spawns a new raindrop at a fixed interval while the game screen is active
   useEffect(() => {
@@ -121,13 +152,31 @@ export const WaterGame = () => {
     return () => clearInterval(interval);
   }, [screen, spawnRaindrop]);
 
+  // Clears current raindrops and loads the next question's choices into the queue
+  const moveToNextQuestion = useCallback(() => {
+    const nextIndex = currentQuestionIndex + 1;
+
+    if (nextIndex >= questions.length) {
+      setScreen("end");
+      return;
+    }
+
+    setCurrentQuestionIndex(nextIndex);
+    console.log(currentQuestionIndex);
+    answerQueueRef.current = questionToRaindropAnswers(questions[nextIndex]);
+    setRaindrops([]);
+  }, [currentQuestionIndex, questions]);
+
   // Moves all raindrops downward on each tick and removes any that have
   // fallen past the bottom of the game screen
+  // Moves all raindrops downward on each tick, checks for bucket collision,
+  // and removes any that have fallen past the bottom of the game screen
   useEffect(() => {
     if (screen !== "game") return;
     if (!gameScreenRef.current) return;
 
     const floorY = gameScreenRef.current.offsetHeight - RAINDROP_HEIGHT;
+    const bucketTop = gameScreenRef.current.offsetHeight - BUCKET_HEIGHT;
 
     const interval = setInterval(() => {
       setRaindrops((prev) =>
@@ -136,12 +185,36 @@ export const WaterGame = () => {
             ...drop,
             y: drop.y + RAINDROP_FALL_SPEED,
           }))
-          .filter((drop) => drop.y < floorY),
+          .filter((drop) => {
+            const raindropRight = drop.x + RAINDROP_WIDTH;
+            const bucketRight = bucketXRef.current + BUCKET_WIDTH; // use ref
+
+            const horizontalOverlap =
+              drop.x < bucketRight && raindropRight > bucketXRef.current;
+            const verticalOverlap = drop.y + RAINDROP_HEIGHT >= bucketTop;
+
+            if (horizontalOverlap && verticalOverlap) {
+              if (!caughtRaindropIds.current.has(drop.id)) {
+                caughtRaindropIds.current.add(drop.id);
+                handleAnswer(drop.isCorrect);
+                moveToNextQuestion();
+              }
+              return false;
+            }
+
+            return drop.y < floorY;
+          }),
       );
-    }, 16);
+    }, 16); // bucketX removed from dependencies
 
     return () => clearInterval(interval);
-  }, [screen]);
+  }, [screen, handleAnswer, moveToNextQuestion]);
+
+  useEffect(() => {
+    console.log("correctCount:", correctCount);
+    console.log("incorrectCount:", incorrectCount);
+    console.log("current question index:", currentQuestionIndex);
+  }, [correctCount, incorrectCount, currentQuestionIndex]);
 
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>{error}</div>;
@@ -239,11 +312,22 @@ export const WaterGame = () => {
             screen="end"
             header="Time's Up"
             buttonText="Go Back to Home"
-            onClick={() => (window.location.href = "/")}
+            onClick={async () => {
+              try {
+                await pushGameResults(
+                  (correctCount / questions.length) * 100,
+                  "water",
+                );
+              } catch {
+                console.error("Failed to update water resource.");
+              } finally {
+                window.location.href = "/";
+              }
+            }}
             textList={[
-              "Number of correctly answered questions: 7",
-              "Number of incorrectly answered questions: 3",
-              "Total number of points earned: 7",
+              `Number of correctly answered questions: ${correctCount}`,
+              `Number of incorrectly answered questions: ${incorrectCount}`,
+              `Total number of points earned: ${correctCount}`,
             ]}
           />
         </div>

--- a/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
@@ -7,14 +7,17 @@ that the components on the game screen (bucket, question, raindrop) render
 and function correctly.
 */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { vi, beforeEach, afterEach } from "vitest";
+
 import { WaterGame } from "../WaterGame";
 import styles from "../WaterGame.module.css";
+import type { RaindropAnswer } from "../types";
 import type { WaterQuestion } from "../../ServerCalls/ServerCalls";
 import * as ServerCalls from "../../ServerCalls/ServerCalls";
+import * as utils from "../utils";
 
 const mockWaterQuestions = [
   {
@@ -164,3 +167,99 @@ test("bucket does not move past the right boundary", async () => {
 
   expect(bucket.style.left).toBe(`${maxRight}px`);
 });
+
+test("displays correct results on end screen after catching a correct raindrop", async () => {
+  vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
+    const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
+    const correct = (array as RaindropAnswer[]).filter((a) => a.isCorrect);
+    return [...correct, ...incorrect];
+  });
+
+  vi.spyOn(Math, "random").mockReturnValue(0.4125);
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <WaterGame />
+    </MemoryRouter>,
+  );
+
+  await screen.findByTestId("water-start");
+  await user.click(screen.getByRole("button", { name: /play/i }));
+  await user.click(screen.getByRole("button", { name: /i'm ready/i }));
+
+  // Wait for game to end after raindrop is caught
+  await waitFor(
+    () => {
+      expect(screen.getByTestId("water-end")).toBeInTheDocument();
+    },
+    { timeout: 5000 },
+  );
+
+  // H2O is the correct answer so correctCount should be 1
+  expect(
+    screen.getByText(/number of correctly answered questions: 1/i),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(/number of incorrectly answered questions: 0/i),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(/total number of points earned: 100/i),
+  ).toBeInTheDocument();
+}, 10000);
+
+test("displays correct results on end screen after catching an incorrect raindrop", async () => {
+  vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
+    const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
+    const correct = (array as RaindropAnswer[]).filter((a) => a.isCorrect);
+    return [...incorrect, ...correct];
+  });
+
+  vi.spyOn(Math, "random").mockReturnValue(0.4125); // raindrop spawns at bucket center
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <WaterGame />
+    </MemoryRouter>,
+  );
+
+  await screen.findByTestId("water-start");
+  await user.click(screen.getByRole("button", { name: /play/i }));
+  await user.click(screen.getByRole("button", { name: /i'm ready/i }));
+
+  await waitFor(
+    () => {
+      expect(screen.getByTestId("water-end")).toBeInTheDocument();
+    },
+    { timeout: 5000 },
+  );
+
+  expect(
+    screen.getByText(/number of correctly answered questions: 0/i),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(/number of incorrectly answered questions: 1/i),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(/total number of points earned: 0/i),
+  ).toBeInTheDocument();
+}, 10000);

--- a/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
@@ -1,10 +1,11 @@
 /*
-Integration tests for the WaterGame component
+Game Screen Integration Tests for the WaterGame Component
 
-This module contains integration tests for the WaterGame component, 
-which is a key part of the client-side application. These tests verify 
-that the components on the game screen (bucket, question, raindrop) render 
-and function correctly.
+This module contains integration tests for the game screen of the WaterGame
+component. These tests verify that the game screen components (question
+container, bucket, raindrops) render correctly, that the bucket moves
+correctly in response to arrow key presses, and that the end screen displays
+the correct results after the player catches a correct or incorrect raindrop.
 */
 
 import { render, screen, waitFor } from "@testing-library/react";

--- a/client/src/pages/WaterGame/__tests__/WaterGame.navigation.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.navigation.test.tsx
@@ -7,10 +7,11 @@ application. These tests verify that the different screens (start, tutorial,
 game, end) render correctly and that navigation between them works as expected.
 */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { vi, beforeEach, afterEach } from "vitest";
+
 import { WaterGame } from "../WaterGame";
 import type { WaterQuestion } from "../../ServerCalls/ServerCalls";
 import * as ServerCalls from "../../ServerCalls/ServerCalls";
@@ -133,3 +134,42 @@ test("renders tutorial header and instructions", async () => {
   const items = screen.getAllByRole("listitem");
   expect(items).toHaveLength(5);
 });
+
+test("renders results screen and game results", async () => {
+  vi.spyOn(Math, "random").mockReturnValue(0.4125);
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <WaterGame />
+    </MemoryRouter>,
+  );
+
+  await screen.findByTestId("water-start");
+  await user.click(screen.getByRole("button", { name: /play/i }));
+  await user.click(screen.getByRole("button", { name: /i'm ready/i }));
+
+  // Wait for the game to end after the only question is answered
+  await waitFor(
+    () => {
+      expect(screen.getByTestId("water-end")).toBeInTheDocument();
+    },
+    { timeout: 5000 },
+  );
+
+  expect(screen.getByText(/game over/i)).toBeInTheDocument();
+
+  const list = screen.getByRole("list");
+  expect(list).toBeInTheDocument();
+
+  const items = screen.getAllByRole("listitem");
+  expect(items).toHaveLength(3);
+}, 10000);

--- a/client/src/pages/WaterGame/__tests__/WaterGame.questions.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.questions.test.tsx
@@ -29,6 +29,19 @@ const mockWaterQuestions = [
       { text: "O2", isCorrect: false },
     ],
   },
+  {
+    questionID: "2",
+    difficulty: 1,
+    resourceType: "Water",
+    text: "What percentage of the earth is covered in water?",
+    type: "MCQ",
+    choices: [
+      { text: "30", isCorrect: false },
+      { text: "50", isCorrect: false },
+      { text: "70", isCorrect: true },
+      { text: "100", isCorrect: false },
+    ],
+  },
 ];
 
 beforeEach(() => {
@@ -81,4 +94,34 @@ test("shows loading indicator while questions are being fetched", async () => {
   expect(screen.getByTestId("water-start")).toBeInTheDocument();
 });
 
-// TODO: Add tests for updated text when move onto next question
+test("question text updates after bucket catching raindrop", async () => {
+  vi.spyOn(Math, "random").mockReturnValue(0.4125);
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <WaterGame />
+    </MemoryRouter>,
+  );
+
+  await screen.findByTestId("water-start");
+  await user.click(screen.getByRole("button", { name: /play/i }));
+  await user.click(screen.getByRole("button", { name: /i'm ready/i }));
+
+  expect(screen.getByText(mockWaterQuestions[0].text)).toBeInTheDocument();
+
+  await waitFor(
+    () => {
+      expect(screen.getByText(mockWaterQuestions[1].text)).toBeInTheDocument();
+    },
+    { timeout: 5000 },
+  );
+}, 10000);

--- a/client/src/pages/WaterGame/__tests__/WaterGame.raindrop.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.raindrop.test.tsx
@@ -19,6 +19,7 @@ import { WaterGame } from "../WaterGame";
 import { SPAWN_INTERVAL_MS, RAINDROP_WIDTH } from "../constants";
 import type { WaterQuestion } from "../../ServerCalls/ServerCalls";
 import * as ServerCalls from "../../ServerCalls/ServerCalls";
+import * as utils from "../utils";
 
 const mockWaterQuestions = [
   {
@@ -81,16 +82,20 @@ test("spawns raindrops within container bounds", async () => {
 test("raindrop moves downward over time", async () => {
   const user = userEvent.setup();
 
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 1000,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
   render(
     <MemoryRouter>
       <WaterGame />
     </MemoryRouter>,
   );
-
-  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
-    configurable: true,
-    value: 1000,
-  });
 
   await screen.findByTestId("water-start");
   await user.click(screen.getByRole("button", { name: /play/i }));
@@ -105,9 +110,7 @@ test("raindrop moves downward over time", async () => {
 
   await waitFor(
     () => {
-      const currentText = screen.getByText("H2O");
-      const currentTop = parseFloat(currentText.closest("div")!.style.top);
-
+      const currentTop = parseFloat(screen.getByTestId("raindrop-0").style.top);
       expect(currentTop).toBeGreaterThan(initialTop);
     },
     { timeout: 1500 },
@@ -162,18 +165,32 @@ test("raindrops spawn at the correct interval", async () => {
 
   expect(screen.queryByTestId("raindrop-0")).not.toBeInTheDocument();
 
-  await screen.findByTestId("raindrop-0", {}, { timeout: SPAWN_INTERVAL_MS });
+  await screen.findByTestId(
+    "raindrop-0",
+    {},
+    { timeout: SPAWN_INTERVAL_MS + 500 },
+  );
   expect(screen.queryByTestId("raindrop-1")).not.toBeInTheDocument();
 
-  await screen.findByTestId("raindrop-1", {}, { timeout: SPAWN_INTERVAL_MS });
+  await screen.findByTestId(
+    "raindrop-1",
+    {},
+    { timeout: SPAWN_INTERVAL_MS + 500 },
+  );
 }, 10000);
 
 test("renders fetched question choices as raindrop answers", async () => {
+  vi.spyOn(utils, "shuffleArray").mockImplementation((array) => array);
+
   const user = userEvent.setup();
 
   Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
     configurable: true,
     value: 1000,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
   });
 
   render(
@@ -186,8 +203,7 @@ test("renders fetched question choices as raindrop answers", async () => {
   await user.click(screen.getByRole("button", { name: /play/i }));
   await user.click(screen.getByRole("button", { name: /i'm ready/i }));
 
-  // Wait for all choices to appear as raindrop answers
-  for (const choice of mockWaterQuestions[0].choices) {
-    await screen.findByText(choice.text, {}, { timeout: 5000 });
-  }
+  await screen.findByText("H2O", {}, { timeout: 5000 });
+  await screen.findByText("CO2", {}, { timeout: 5000 });
+  await screen.findByText("O2", {}, { timeout: 5000 });
 }, 10000);

--- a/client/src/pages/WaterGame/__tests__/collision.test.ts
+++ b/client/src/pages/WaterGame/__tests__/collision.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { checkCollision } from "../collision";
+import { BUCKET_WIDTH } from "../constants";
+
+describe("checkCollision", () => {
+  // dropX=100, bucketX=100: raindropRight=196, bucketRight=240 → full overlap
+  it("detects collision when raindrop fully overlaps with bucket", () => {
+    expect(checkCollision(100, 800, 100, 750)).toBe(true);
+  });
+
+  // dropX=50, bucketX=100: raindropRight=146, bucketRight=240 → partial left overlap
+  it("detects collision when raindrop partially overlaps bucket from the left", () => {
+    expect(checkCollision(50, 800, 100, 750)).toBe(true);
+  });
+
+  // dropX=200, bucketX=100: raindropRight=296, bucketRight=240 → partial right overlap
+  it("detects collision when raindrop partially overlaps bucket from the right", () => {
+    expect(checkCollision(200, 800, 100, 750)).toBe(true);
+  });
+
+  // dropX=0, bucketX=200: raindropRight=96, bucketRight=340 → raindrop entirely left of bucket
+  it("no collision when raindrop is entirely to the left of bucket", () => {
+    expect(checkCollision(0, 800, 200, 750)).toBe(false);
+  });
+
+  // dropX=400, bucketX=100: raindropRight=496, bucketRight=240 → raindrop entirely right of bucket
+  it("no collision when raindrop is entirely to the right of bucket", () => {
+    expect(checkCollision(400, 800, 100, 750)).toBe(false);
+  });
+
+  // dropX=100, dropY=100: dropY + RAINDROP_HEIGHT=228, bucketTop=750 → raindrop too high
+  it("no collision when raindrop has not reached bucket height", () => {
+    expect(checkCollision(100, 100, 100, 750)).toBe(false);
+  });
+
+  // dropX=0, dropY=800, bucketX=200: no horizontal overlap despite vertical overlap
+  it("no collision when raindrop is at bucket height but has no horizontal overlap", () => {
+    expect(checkCollision(0, 800, 200, 750)).toBe(false);
+  });
+
+  // dropX=100, dropY=622: dropY + RAINDROP_HEIGHT=750 → exactly at bucketTop boundary
+  it("detects collision when raindrop bottom is exactly at bucket top boundary", () => {
+    expect(checkCollision(100, 622, 100, 750)).toBe(true);
+  });
+
+  // dropX=bucketX + BUCKET_WIDTH: raindropRight=236, bucketRight=240 → just inside right edge
+  it("detects collision when raindrop is just inside the right edge of bucket", () => {
+    expect(checkCollision(BUCKET_WIDTH - 1, 800, 0, 750)).toBe(true);
+  });
+
+  // dropX=BUCKET_WIDTH: raindropRight=236, bucketRight=140 → just outside right edge
+  it("no collision when raindrop is just outside the right edge of bucket", () => {
+    expect(checkCollision(BUCKET_WIDTH, 800, 0, 750)).toBe(false);
+  });
+});

--- a/client/src/pages/WaterGame/__tests__/collision.test.ts
+++ b/client/src/pages/WaterGame/__tests__/collision.test.ts
@@ -1,3 +1,12 @@
+/*
+Unit Tests for the checkCollision Function
+
+This module contains unit tests for the checkCollision function, which determines
+whether a falling raindrop has collided with the bucket. Tests cover full overlap,
+partial overlaps from both sides, misses to the left and right, vertical boundary
+conditions, and exact edge cases at the bucket's boundaries.
+*/
+
 import { describe, it, expect } from "vitest";
 import { checkCollision } from "../collision";
 import { BUCKET_WIDTH } from "../constants";

--- a/client/src/pages/WaterGame/collision.ts
+++ b/client/src/pages/WaterGame/collision.ts
@@ -1,0 +1,16 @@
+import { RAINDROP_HEIGHT, RAINDROP_WIDTH, BUCKET_WIDTH } from "./constants";
+
+export const checkCollision = (
+  dropX: number,
+  dropY: number,
+  bucketX: number,
+  bucketTop: number,
+): boolean => {
+  const raindropRight = dropX + RAINDROP_WIDTH;
+  const bucketRight = bucketX + BUCKET_WIDTH;
+
+  const horizontalOverlap = dropX < bucketRight && raindropRight > bucketX;
+  const verticalOverlap = dropY + RAINDROP_HEIGHT >= bucketTop;
+
+  return horizontalOverlap && verticalOverlap;
+};

--- a/client/src/pages/WaterGame/components/Raindrop.module.css
+++ b/client/src/pages/WaterGame/components/Raindrop.module.css
@@ -19,4 +19,5 @@
   font-size: 2.5rem;
   font-weight: 400;
   margin: 0;
+  word-break: break-word;
 }

--- a/client/src/pages/WaterGame/components/Raindrop.tsx
+++ b/client/src/pages/WaterGame/components/Raindrop.tsx
@@ -8,13 +8,21 @@ export type RaindropProps = {
 };
 
 export const Raindrop = ({ id, x, y, answer }: RaindropProps) => {
+  const getFontSize = (text: string) => {
+    if (text.length > 12) return "0.75rem";
+    if (text.length > 4) return "1.5rem";
+    return "2.5rem";
+  };
+
   return (
     <div
       className={styles.raindrop}
       data-testid={`raindrop-${id}`}
       style={{ left: x, top: y }}
     >
-      <span className={styles.answer}>{answer}</span>
+      <span className={styles.answer} style={{ fontSize: getFontSize(answer) }}>
+        {answer}
+      </span>
     </div>
   );
 };

--- a/client/src/pages/WaterGame/constants.tsx
+++ b/client/src/pages/WaterGame/constants.tsx
@@ -11,4 +11,5 @@ export const RAINDROP_HEIGHT = 128; // 8rem
 export const RAINDROP_FALL_SPEED = 1.2;
 export const SPAWN_INTERVAL_MS = 1750;
 export const BUCKET_WIDTH = 140;
+export const BUCKET_HEIGHT = 140;
 export const NUM_QUESTIONS = 3;

--- a/client/src/pages/WaterGame/constants.tsx
+++ b/client/src/pages/WaterGame/constants.tsx
@@ -1,11 +1,3 @@
-export const SAMPLE_ANSWERS = [
-  { text: "H2O", isCorrect: true },
-  { text: "CO2", isCorrect: false },
-  { text: "O2", isCorrect: false },
-  { text: "NaCl", isCorrect: false },
-  { text: "O2", isCorrect: false },
-  { text: "He", isCorrect: false },
-];
 export const RAINDROP_WIDTH = 96; // 6rem
 export const RAINDROP_HEIGHT = 128; // 8rem
 export const RAINDROP_FALL_SPEED = 1.2;

--- a/client/src/pages/WaterGame/hooks/useWaterGameQuestions.tsx
+++ b/client/src/pages/WaterGame/hooks/useWaterGameQuestions.tsx
@@ -26,7 +26,6 @@ export const useWaterGameQuestions = (): UseWaterGameQuestionsResult => {
     const loadQuestions = async () => {
       try {
         const fetched = await fetchQuestions("Water", NUM_QUESTIONS, "MCQ");
-        console.log("fetched questions:", fetched);
         setQuestions(fetched);
       } catch {
         setError("Failed to load questions. Please try again.");

--- a/client/src/pages/WaterGame/utils.tsx
+++ b/client/src/pages/WaterGame/utils.tsx
@@ -1,6 +1,7 @@
 import type { WaterQuestion } from "../ServerCalls/ServerCalls";
 import type { RaindropAnswer } from "./types";
 
+// Converts a WaterQuestion's choices into the RaindropAnswer format used by the game
 export const questionToRaindropAnswers = (
   question: WaterQuestion,
 ): RaindropAnswer[] => {
@@ -10,6 +11,7 @@ export const questionToRaindropAnswers = (
   }));
 };
 
+// Shuffles an array into a random order
 export const shuffleArray = <T,>(array: T[]): T[] => {
   return [...array].sort(() => Math.random() - 0.5);
 };

--- a/client/src/pages/WaterGame/utils.tsx
+++ b/client/src/pages/WaterGame/utils.tsx
@@ -9,3 +9,7 @@ export const questionToRaindropAnswers = (
     isCorrect: choice.isCorrect,
   }));
 };
+
+export const shuffleArray = <T,>(array: T[]): T[] => {
+  return [...array].sort(() => Math.random() - 0.5);
+};


### PR DESCRIPTION
## What

- Added frontend interaction between bucket and raindrop
- added states for correct/incorrect number of questions answered
- hooked up backend to results modal button to update resource levels in database
- Added unit & end-to-end tests for results modal
- added tests for interaction between bucket and raindrop

## Why

- core gameplay functionality for water minigame
- updating progress back to homepage

## How

- worked independently

## Test Steps

What are all the steps to testing your code changes?

- [x] `cd server`
- [x] run `python -m Database.createDatabase` to create the database
- [x] cd out of server (`cd ..`)
- [x] run `python -m utils.addDefaultQuestions` to populate question list
- [x] boot up backend and frontend and ensure everything looks ok
- [x] run `npm run test`

## Other Notes

- will be adding frontend popup that appears to inform user whether they correctly/incorrectly answer a question in real time