### PR TITLE
Raingame answer popup

### DIFF
--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -28,27 +28,26 @@
   --color-grey0: #d9d9d9;
   --color-grey1: #a9a9a9;
 
-  --color-darkGreen: #2F7B16;
-  --color-lightGreen: #A2CA38;
-  --color-bgGreen: #BEE751;
+  --color-darkGreen: #2f7b16;
+  --color-lightGreen: #a2ca38;
+  --color-bgGreen: #bee751;
 
-  --color-lightYellow: #FFD700;
-  --color-darkYellow: #FFA500;
+  --color-lightYellow: #ffd700;
+  --color-darkYellow: #ffa500;
 
   --color-error: #ff4848;
+  --color-incorrect: #e45d5d;
   --color-success: #8fe45d;
 
   background-size: auto;
 }
 
-
-
 html,
 body {
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    font-family: "Handjet", sans-serif;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  font-family: "Handjet", sans-serif;
 }
 
 /* body {

--- a/client/src/pages/ServerCalls/ServerCalls.ts
+++ b/client/src/pages/ServerCalls/ServerCalls.ts
@@ -1,60 +1,43 @@
-// Types:
-interface QuestionChoice {
-  text: string;
-  isCorrect: boolean;
-}
-
 /**
- * TODO:
- * Question is formatted wrong for Soilminigame
- * 1) explicitly define resourceType as "earth" and "water"
- * 2) Abstract a BaseQuestion to only house the common fields
- * 3) Extend BaseQuestion with the earth and water minigame extensions
- *      (these contain the updated question and answer fields)
- * 4) Have AI rewrite some tests for this implementation
- *      (half of the current tests should become invalid due to the wrong soil game question format)
- * 5) Ensure the backend follows the naming convention used here
+ * This file contains functions for making API calls to the server related to fetching questions and pushing game results.
+ * It defines the expected request and response formats for these API calls.
+ * 
+ * fetchQuestions: Fetches a list of questions from the server based on specified filters (number of questions, resource type, question type, difficulty).
+ * pushGameResults: Sends the player's game progress to the server to update the corresponding resource levels.
+ * 
+ * The question and response formats are defined as TypeScript interfaces.
+ * 
+ * Reference constants.py for valid resource types and question types.
+ * Reference main.py for API endpoint implementations and expected request/response handling.
+ * 
+ * Example usage:
+ * const questions = await fetchQuestions(5, "earth", "MultiSelect", 1);
+ * const success = await pushGameResults(10, "earth");
  */
 
-// Used to determine what questions to filter by
-type ResourceType = "Earth" | "Water";
-
-type QuestionMap = {
-  Water: WaterQuestion;
-  Earth: EarthQuestion;
-};
-
-export interface BaseQuestion {
-  questionID: string;
-  difficulty: number;
-  resourceType: ResourceType;
+interface QuestionChoice {
+    text: string;
+    isCorrect: boolean;
 }
 
-export interface WaterQuestion extends BaseQuestion {
-  resourceType: "Water";
-  text: string;
-  type: string;
-  choices: QuestionChoice[];
+export interface Question {
+    questionID: string;
+    text: string;
+    type: string;
+    difficulty: number;
+    resourceType: string;
+    choices: QuestionChoice[];
 }
 
-export interface EarthQuestion extends BaseQuestion {
-  resourceType: "Earth";
-  moleculeName: string;
-  moleculeFormula: string;
-  required: Record<string, number>;
-}
-
-export type Question = WaterQuestion | EarthQuestion;
-
-interface GetQuestionsResponse<T> {
-  success: boolean;
-  count: number;
-  questions: T[];
+interface GetQuestionsResponse {
+    success: boolean;
+    count: number;
+    questions: Question[];
 }
 
 interface UpdateStatResponse {
-  success: boolean;
-  message: string;
+    success: boolean;
+    message: string;
 }
 
 /**
@@ -65,36 +48,36 @@ interface UpdateStatResponse {
  * @param difficulty - Filter by difficulty level (not implemented yet)
  * @returns Array of questions
  */
-export async function fetchQuestions<T extends ResourceType>(
-  resourceType: T,
-  numQuestions?: number,
-  questionType?: string,
-  difficulty?: number,
-): Promise<QuestionMap[T][]> {
-  const response = await fetch("/api/get-questions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      numQuestions,
-      resourceType,
-      questionType,
-      difficulty,
-    }),
-  });
+export async function fetchQuestions(
+    numQuestions?: number,
+    resourceType?: string,
+    questionType?: string,
+    difficulty?: number
+): Promise<Question[]> {
+    const response = await fetch('/api/get-questions', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            numQuestions,
+            resourceType,
+            questionType,
+            difficulty,
+        }),
+    });
 
-  if (!response.ok) {
-    throw new Error("Failed to fetch questions");
-  }
+    if (!response.ok) {
+        throw new Error('Failed to fetch questions');
+    }
 
-  const data: GetQuestionsResponse<QuestionMap[T]> = await response.json();
+    const data: GetQuestionsResponse = await response.json();
 
-  if (!data.success) {
-    throw new Error("Server returned unsuccessful response");
-  }
+    if (!data.success) {
+        throw new Error('Server returned unsuccessful response');
+    }
 
-  return data.questions as QuestionMap[T][];
+    return data.questions;
 }
 
 /**
@@ -103,34 +86,29 @@ export async function fetchQuestions<T extends ResourceType>(
  * @param gameType - Resource type to update: "water", "earth", or "sun"
  * @returns Promise<boolean> - true if update was successful
  */
-export async function pushGameResults(
-  progress: number,
-  gameType: string,
-): Promise<boolean> {
-  const statName = gameType.toLowerCase();
+export async function pushGameResults(progress: number, gameType: string): Promise<boolean> {
+    const statName = gameType.toLowerCase();
+    
+    if (!['water', 'earth', 'sun'].includes(statName)) {
+        throw new Error(`Invalid gameType: ${gameType}. Must be "water", "earth", or "sun"`);
+    }
 
-  if (!["water", "earth", "sun"].includes(statName)) {
-    throw new Error(
-      `Invalid gameType: ${gameType}. Must be "water", "earth", or "sun"`,
-    );
-  }
+    const response = await fetch('/api/update-stat', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            stat_name: statName,
+            value: progress,
+        }),
+    });
 
-  const response = await fetch("/api/update-stat", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      stat_name: statName,
-      value: progress,
-    }),
-  });
+    if (!response.ok) {
+        throw new Error(`Failed to update stat: ${response.statusText}`);
+    }
 
-  if (!response.ok) {
-    throw new Error(`Failed to update stat: ${response.statusText}`);
-  }
-
-  const data: UpdateStatResponse = await response.json();
-
-  return data.success;
+    const data: UpdateStatResponse = await response.json();
+    
+    return data.success;
 }

--- a/client/src/pages/ServerCalls/__tests__/ServerCalls.test.ts
+++ b/client/src/pages/ServerCalls/__tests__/ServerCalls.test.ts
@@ -6,32 +6,49 @@ describe("fetchQuestions", () => {
     vi.restoreAllMocks();
   });
 
-  const mockWaterQuestions = [
+  const mockQuestions = [
     {
-      questionID: "1",
+      questionID: "q1",
+      difficulty: 1,
+      resourceType: "Sun",
+      text: "What is the powerhouse of the cell?",
+      type: "MCQ",
+      choices: [
+        { text: "The mitochondria", isCorrect: true },
+        { text: "The nucleus", isCorrect: false },
+        { text: "The ribosome", isCorrect: false },
+        { text: "The endoplasmic reticulum", isCorrect: false },
+      ],
+    },
+    {
+      questionID: "q2",
       difficulty: 1,
       resourceType: "Water",
       text: "What is H2O?",
-      type: "mcq",
+      type: "MCQ",
       choices: [
+        { text: "Hydrogen Peroxide", isCorrect: false },
         { text: "Water", isCorrect: true },
-        { text: "Oxygen", isCorrect: false },
+        { text: "Hydrochloric Acid", isCorrect: false },
+        { text: "Heavy Water", isCorrect: false },
+      ],
+    },
+    {
+      questionID: "q3",
+      difficulty: 1,
+      resourceType: "Earth",
+      text: "What are the main components of soil?",
+      type: "MultiSelect",
+      choices: [
+        { text: "Minerals", isCorrect: true },
+        { text: "Organic matter", isCorrect: true },
+        { text: "Water", isCorrect: true },
+        { text: "Air", isCorrect: true },
       ],
     },
   ];
 
-  const mockEarthQuestions = [
-    {
-      questionID: "2",
-      difficulty: 2,
-      resourceType: "Earth",
-      moleculeName: "Water",
-      moleculeFormula: "H2O",
-      required: { H: 2, O: 1 },
-    },
-  ];
-
-  it("fetches water questions successfully", async () => {
+  it("fetches questions successfully", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
 
     fetchMock.mockResolvedValue({
@@ -39,41 +56,22 @@ describe("fetchQuestions", () => {
       json: async () => ({
         success: true,
         count: 1,
-        questions: mockWaterQuestions,
+        questions: mockQuestions,
       }),
     } as any);
 
-    const result = await fetchQuestions("Water");
+    const result = await fetchQuestions();
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/get-questions",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
-    expect(result).toEqual(mockWaterQuestions);
-    expect(result[0].resourceType).toBe("Water");
+    expect(result).toEqual(mockQuestions);
+    expect(result[0].resourceType).toBe("Sun");
     expect(result[0]).toHaveProperty("choices");
-  });
-
-  it("fetches earth questions successfully", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch");
-
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        success: true,
-        count: 1,
-        questions: mockEarthQuestions,
-      }),
-    } as any);
-
-    const result = await fetchQuestions("Earth");
-
-    expect(result).toEqual(mockEarthQuestions);
-    expect(result[0].resourceType).toBe("Earth");
-    expect(result[0]).toHaveProperty("moleculeFormula");
   });
 
   it("throws if response is not ok", async () => {
@@ -82,8 +80,8 @@ describe("fetchQuestions", () => {
       status: 500,
     } as any);
 
-    await expect(fetchQuestions("Water")).rejects.toThrow(
-      "Failed to fetch questions",
+    await expect(fetchQuestions(undefined, "water")).rejects.toThrow(
+      "Failed to fetch questions"
     );
   });
 
@@ -97,8 +95,8 @@ describe("fetchQuestions", () => {
       }),
     } as any);
 
-    await expect(fetchQuestions("Water")).rejects.toThrow(
-      "Server returned unsuccessful response",
+    await expect(fetchQuestions(undefined, "water")).rejects.toThrow(
+      "Server returned unsuccessful response"
     );
   });
 
@@ -114,7 +112,7 @@ describe("fetchQuestions", () => {
       }),
     } as any);
 
-    await fetchQuestions("Water", 5, "mcq", 2);
+    await fetchQuestions(5, "Water", "MCQ", 2);
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/get-questions",
@@ -122,10 +120,10 @@ describe("fetchQuestions", () => {
         body: JSON.stringify({
           numQuestions: 5,
           resourceType: "Water",
-          questionType: "mcq",
+          questionType: "MCQ",
           difficulty: 2,
         }),
-      }),
+      })
     );
   });
 });
@@ -152,16 +150,16 @@ describe("pushGameResults", () => {
       "/api/update-stat",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
 
     expect(result).toBe(true);
   });
 
   it("throws if invalid gameType is provided", async () => {
-    await expect(pushGameResults(10, "invalid" as any)).rejects.toThrow(
-      "Invalid gameType",
-    );
+    await expect(
+      pushGameResults(10, "invalid" as any)
+    ).rejects.toThrow("Invalid gameType");
   });
 
   it("throws if response is not ok", async () => {
@@ -171,7 +169,7 @@ describe("pushGameResults", () => {
     } as any);
 
     await expect(pushGameResults(10, "water")).rejects.toThrow(
-      "Failed to update stat",
+      "Failed to update stat"
     );
   });
 

--- a/client/src/pages/WaterGame/WaterGame.module.css
+++ b/client/src/pages/WaterGame/WaterGame.module.css
@@ -56,6 +56,24 @@
   margin: 0;
 }
 
+.pointCount {
+  display: flex;
+  padding: 20px;
+  align-items: center;
+  position: absolute;
+  right: 4rem;
+  top: 4rem;
+  border-radius: 30px;
+  background-color: color-mix(in srgb, var(--color-blue2) 80%, transparent);
+}
+
+.pointCountText {
+  color: #fff;
+  text-align: center;
+  font-size: 2rem;
+  margin: 0;
+}
+
 .bucketContainer {
   position: relative;
   width: 100%;

--- a/client/src/pages/WaterGame/WaterGame.tsx
+++ b/client/src/pages/WaterGame/WaterGame.tsx
@@ -27,7 +27,7 @@ import Bucket from "./components/Bucket";
 import { Raindrop } from "./components/Raindrop";
 import { Point } from "./components/Point";
 
-import type { RaindropData, RaindropAnswer } from "./types";
+import type { RaindropData, RaindropAnswer, PointData } from "./types";
 import {
   RAINDROP_FALL_SPEED,
   RAINDROP_HEIGHT,
@@ -35,6 +35,8 @@ import {
   SPAWN_INTERVAL_MS,
   BUCKET_WIDTH,
   BUCKET_HEIGHT,
+  POINT_DURATION_MS,
+  POINT_WIDTH,
 } from "./constants";
 
 import styles from "./WaterGame.module.css";
@@ -54,6 +56,9 @@ export const WaterGame = () => {
   const [raindrops, setRaindrops] = useState<RaindropData[]>([]);
   const nextRaindropId = useRef(0);
   const caughtRaindropIds = useRef<Set<number>>(new Set());
+
+  const [points, setPoints] = useState<PointData[]>([]);
+  const nextPointId = useRef(0);
 
   const answerQueueRef = useRef<RaindropAnswer[]>([]);
   const { questions, isLoading, error } = useWaterGameQuestions();
@@ -116,6 +121,8 @@ export const WaterGame = () => {
     setCurrentQuestionIndex(0);
     setCorrectCount(0);
     setIncorrectCount(0);
+    setPoints([]);
+    nextPointId.current = 0;
     caughtRaindropIds.current = new Set();
     setScreen("game");
   };
@@ -172,6 +179,30 @@ export const WaterGame = () => {
     ]);
   }, [currentQuestionIndex, questions]);
 
+  // Spawns a point indicator above the bucket and removes it after POINT_DURATION_MS
+  const spawnPoint = useCallback((isCorrect: boolean) => {
+    const id = nextPointId.current++;
+    const padding = gameScreenRef.current
+      ? parseFloat(getComputedStyle(gameScreenRef.current).paddingBottom)
+      : 0;
+
+    setPoints((prev) => [
+      ...prev,
+      {
+        id,
+        x: bucketXRef.current + (BUCKET_WIDTH / 2 - POINT_WIDTH / 2) + padding,
+        y: gameScreenRef.current
+          ? gameScreenRef.current.offsetHeight - BUCKET_HEIGHT - 72 - padding
+          : 0,
+        variant: isCorrect ? "correct" : "incorrect",
+      },
+    ]);
+
+    setTimeout(() => {
+      setPoints((prev) => prev.filter((p) => p.id !== id));
+    }, POINT_DURATION_MS);
+  }, []);
+
   // Spawns a new raindrop at a fixed interval while the game screen is active
   useEffect(() => {
     if (screen !== "game") return;
@@ -220,6 +251,7 @@ export const WaterGame = () => {
               if (!caughtRaindropIds.current.has(drop.id)) {
                 caughtRaindropIds.current.add(drop.id);
                 handleAnswer(drop.isCorrect);
+                spawnPoint(drop.isCorrect);
                 moveToNextQuestion();
               }
               return false;
@@ -231,7 +263,7 @@ export const WaterGame = () => {
     }, 16);
 
     return () => clearInterval(interval);
-  }, [screen, handleAnswer, moveToNextQuestion]);
+  }, [screen, handleAnswer, moveToNextQuestion, spawnPoint]);
 
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>{error}</div>;
@@ -246,7 +278,6 @@ export const WaterGame = () => {
             className={styles.arrow}
             onClick={() => navigate("/")}
           />
-          <Point id={0} x={40} y={40} variant="incorrect" />
           <Popup
             variant="water"
             screen="start"
@@ -296,6 +327,15 @@ export const WaterGame = () => {
               {questions[currentQuestionIndex]?.text}
             </p>
           </span>
+          {points.map((point) => (
+            <Point
+              key={point.id}
+              id={point.id}
+              x={point.x}
+              y={point.y}
+              variant={point.variant}
+            />
+          ))}
           {raindrops.map((drop) => (
             <Raindrop
               id={drop.id}

--- a/client/src/pages/WaterGame/WaterGame.tsx
+++ b/client/src/pages/WaterGame/WaterGame.tsx
@@ -307,11 +307,11 @@ export const WaterGame = () => {
             buttonText={isLoading ? "Loading..." : "I'm Ready"}
             onClick={() => startGame()}
             textList={[
-              "A question will appear at the top of the screen",
+              "Questions will appear at the top of the screen",
               "Raindrops will fall, each with a possible answer",
-              "Catch the correct answer to earn a point",
               "Move the bucket left and right using the arrow keys on your keyboard",
-              "Goal: Collect as many raindrops as you can to gather water for your tree!",
+              "Catch the correct answer to earn 10 points",
+              "Goal: Collect as many raindrops as you can!",
             ]}
           />
         </div>
@@ -326,6 +326,11 @@ export const WaterGame = () => {
             <p className={styles.questionText}>
               {questions[currentQuestionIndex]?.text}
             </p>
+          </span>
+          <span data-testid="point-count" className={styles.pointCount}>
+            <p
+              className={styles.pointCountText}
+            >{`${correctCount * 10} Points`}</p>
           </span>
           {points.map((point) => (
             <Point
@@ -360,14 +365,11 @@ export const WaterGame = () => {
           <Popup
             variant="water"
             screen="end"
-            header="Game Over"
+            header="Good Job!"
             buttonText="Go Back to Home"
             onClick={async () => {
               try {
-                await pushGameResults(
-                  (correctCount / questions.length) * 100,
-                  "water",
-                );
+                await pushGameResults(correctCount * 10, "water");
               } catch {
                 console.error("Failed to update water resource.");
               } finally {
@@ -377,7 +379,7 @@ export const WaterGame = () => {
             textList={[
               `Number of correctly answered questions: ${correctCount}`,
               `Number of incorrectly answered questions: ${incorrectCount}`,
-              `Total number of points earned: ${Math.ceil((correctCount / questions.length) * 100)}`,
+              `Total number of points earned: ${correctCount * 10}`,
             ]}
           />
         </div>

--- a/client/src/pages/WaterGame/WaterGame.tsx
+++ b/client/src/pages/WaterGame/WaterGame.tsx
@@ -20,11 +20,13 @@ import { useNavigate } from "react-router-dom";
 import { useWaterGameQuestions } from "./hooks/useWaterGameQuestions";
 import { pushGameResults } from "../ServerCalls/ServerCalls";
 import { checkCollision } from "./collision";
-
 import { questionToRaindropAnswers, shuffleArray } from "./utils";
+
 import { Popup } from "../../components/Popup";
 import Bucket from "./components/Bucket";
 import { Raindrop } from "./components/Raindrop";
+import { Point } from "./components/Point";
+
 import type { RaindropData, RaindropAnswer } from "./types";
 import {
   RAINDROP_FALL_SPEED,
@@ -244,6 +246,7 @@ export const WaterGame = () => {
             className={styles.arrow}
             onClick={() => navigate("/")}
           />
+          <Point id={0} x={40} y={40} variant="incorrect" />
           <Popup
             variant="water"
             screen="start"

--- a/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
@@ -64,6 +64,10 @@ test("renders game screen and checks for all components", async () => {
   const question = screen.getByTestId("question");
   expect(question).toBeInTheDocument();
 
+  const pointCount = screen.getByTestId("point-count");
+  expect(pointCount).toBeInTheDocument();
+  expect(pointCount).toHaveClass(styles.pointCount);
+
   const bucketContainer = screen.getByTestId("bucket-container");
   expect(bucketContainer).toBeInTheDocument();
   expect(bucketContainer).toHaveClass(styles.bucketContainer);
@@ -213,7 +217,7 @@ test("displays correct results on end screen after catching a correct raindrop",
     screen.getByText(/number of incorrectly answered questions: 0/i),
   ).toBeInTheDocument();
   expect(
-    screen.getByText(/total number of points earned: 100/i),
+    screen.getByText(/total number of points earned: 10/i),
   ).toBeInTheDocument();
 }, 10000);
 
@@ -452,3 +456,127 @@ test("point indicator disappears after duration", async () => {
     { timeout: 5000 },
   );
 }, 15000);
+
+// Checks that point counter display increases when bucket catches correct raindrop
+test("displays correct point count when bucket catches correct raindrop", async () => {
+  vi.spyOn(ServerCalls, "fetchQuestions").mockResolvedValue([
+    {
+      questionID: "1",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What is the chemical formula for water?",
+      type: "MCQ",
+      choices: [
+        { text: "H2O", isCorrect: true },
+        { text: "CO2", isCorrect: false },
+        { text: "O2", isCorrect: false },
+      ],
+    },
+    {
+      questionID: "2",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What percentage of the earth is covered in water?",
+      type: "MCQ",
+      choices: [
+        { text: "70", isCorrect: true },
+        { text: "30", isCorrect: false },
+        { text: "50", isCorrect: false },
+      ],
+    },
+  ] as WaterQuestion[]);
+
+  vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
+    const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
+    const correct = (array as RaindropAnswer[]).filter((a) => a.isCorrect);
+    return [...correct, ...incorrect];
+  });
+
+  vi.spyOn(Math, "random").mockReturnValue(0.4125);
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <WaterGame />
+    </MemoryRouter>,
+  );
+
+  await screen.findByTestId("water-start");
+  await user.click(screen.getByRole("button", { name: /play/i }));
+  await user.click(screen.getByRole("button", { name: /i'm ready/i }));
+
+  const pointCount = screen.getByTestId("point-count");
+  await screen.findByTestId("point-0", {}, { timeout: 5000 });
+  expect(pointCount.textContent?.trim()).toContain(`${NUM_POINTS} Points`);
+}, 10000);
+
+// Checks that point counter display doesn't increase when bucket catches incorrect raindrop
+test("displays correct point counter display when bucket catches incorrect raindrop", async () => {
+  vi.spyOn(ServerCalls, "fetchQuestions").mockResolvedValue([
+    {
+      questionID: "1",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What is the chemical formula for water?",
+      type: "MCQ",
+      choices: [
+        { text: "H2O", isCorrect: true },
+        { text: "CO2", isCorrect: false },
+        { text: "O2", isCorrect: false },
+      ],
+    },
+    {
+      questionID: "2",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What percentage of the earth is covered in water?",
+      type: "MCQ",
+      choices: [
+        { text: "70", isCorrect: true },
+        { text: "30", isCorrect: false },
+        { text: "50", isCorrect: false },
+      ],
+    },
+  ] as WaterQuestion[]);
+
+  vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
+    const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
+    const correct = (array as RaindropAnswer[]).filter((a) => a.isCorrect);
+    return [...incorrect, ...correct];
+  });
+
+  vi.spyOn(Math, "random").mockReturnValue(0.4125);
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <WaterGame />
+    </MemoryRouter>,
+  );
+
+  await screen.findByTestId("water-start");
+  await user.click(screen.getByRole("button", { name: /play/i }));
+  await user.click(screen.getByRole("button", { name: /i'm ready/i }));
+
+  const pointCount = screen.getByTestId("point-count");
+  await screen.findByTestId("point-0", {}, { timeout: 5000 });
+  expect(pointCount.textContent?.trim()).toContain(`0 Points`);
+}, 10000);

--- a/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
@@ -19,6 +19,7 @@ import type { RaindropAnswer } from "../types";
 import type { WaterQuestion } from "../../ServerCalls/ServerCalls";
 import * as ServerCalls from "../../ServerCalls/ServerCalls";
 import * as utils from "../utils";
+import { INCORRECT, NUM_POINTS } from "../constants";
 
 const mockWaterQuestions = [
   {
@@ -198,7 +199,6 @@ test("displays correct results on end screen after catching a correct raindrop",
   await user.click(screen.getByRole("button", { name: /play/i }));
   await user.click(screen.getByRole("button", { name: /i'm ready/i }));
 
-  // Wait for game to end after raindrop is caught
   await waitFor(
     () => {
       expect(screen.getByTestId("water-end")).toBeInTheDocument();
@@ -206,7 +206,6 @@ test("displays correct results on end screen after catching a correct raindrop",
     { timeout: 5000 },
   );
 
-  // H2O is the correct answer so correctCount should be 1
   expect(
     screen.getByText(/number of correctly answered questions: 1/i),
   ).toBeInTheDocument();
@@ -264,3 +263,192 @@ test("displays correct results on end screen after catching an incorrect raindro
     screen.getByText(/total number of points earned: 0/i),
   ).toBeInTheDocument();
 }, 10000);
+
+// Checks that a correct point indicator appears when the bucket catches a correct raindrop
+test("displays correct point indicator when bucket catches correct raindrop", async () => {
+  vi.spyOn(ServerCalls, "fetchQuestions").mockResolvedValue([
+    {
+      questionID: "1",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What is the chemical formula for water?",
+      type: "MCQ",
+      choices: [
+        { text: "H2O", isCorrect: true },
+        { text: "CO2", isCorrect: false },
+        { text: "O2", isCorrect: false },
+      ],
+    },
+    {
+      questionID: "2",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What percentage of the earth is covered in water?",
+      type: "MCQ",
+      choices: [
+        { text: "70", isCorrect: true },
+        { text: "30", isCorrect: false },
+        { text: "50", isCorrect: false },
+      ],
+    },
+  ] as WaterQuestion[]);
+
+  vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
+    const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
+    const correct = (array as RaindropAnswer[]).filter((a) => a.isCorrect);
+    return [...correct, ...incorrect];
+  });
+
+  vi.spyOn(Math, "random").mockReturnValue(0.4125);
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <WaterGame />
+    </MemoryRouter>,
+  );
+
+  await screen.findByTestId("water-start");
+  await user.click(screen.getByRole("button", { name: /play/i }));
+  await user.click(screen.getByRole("button", { name: /i'm ready/i }));
+
+  // Wait for correct point indicator to appear
+  const point = await screen.findByTestId("point-0", {}, { timeout: 5000 });
+  expect(point.textContent?.trim()).toContain(`+${NUM_POINTS}`);
+}, 10000);
+
+// Checks that an incorrect point indicator appears when the bucket catches an incorrect raindrop
+test("displays incorrect point indicator when bucket catches incorrect raindrop", async () => {
+  vi.spyOn(ServerCalls, "fetchQuestions").mockResolvedValue([
+    {
+      questionID: "1",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What is the chemical formula for water?",
+      type: "MCQ",
+      choices: [
+        { text: "H2O", isCorrect: true },
+        { text: "CO2", isCorrect: false },
+        { text: "O2", isCorrect: false },
+      ],
+    },
+    {
+      questionID: "2",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What percentage of the earth is covered in water?",
+      type: "MCQ",
+      choices: [
+        { text: "70", isCorrect: true },
+        { text: "30", isCorrect: false },
+        { text: "50", isCorrect: false },
+      ],
+    },
+  ] as WaterQuestion[]);
+
+  vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
+    const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
+    const correct = (array as RaindropAnswer[]).filter((a) => a.isCorrect);
+    return [...incorrect, ...correct];
+  });
+
+  vi.spyOn(Math, "random").mockReturnValue(0.4125);
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <WaterGame />
+    </MemoryRouter>,
+  );
+
+  await screen.findByTestId("water-start");
+  await user.click(screen.getByRole("button", { name: /play/i }));
+  await user.click(screen.getByRole("button", { name: /i'm ready/i }));
+
+  // Wait for incorrect point indicator to appear
+  const point = await screen.findByTestId("point-0", {}, { timeout: 5000 });
+  expect(point.textContent?.trim()).toContain(INCORRECT);
+}, 10000);
+
+// Checks that the point indicator disappears after POINT_DURATION_MS
+test("point indicator disappears after duration", async () => {
+  vi.spyOn(ServerCalls, "fetchQuestions").mockResolvedValue([
+    {
+      questionID: "1",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What is the chemical formula for water?",
+      type: "MCQ",
+      choices: [
+        { text: "H2O", isCorrect: true },
+        { text: "CO2", isCorrect: false },
+        { text: "O2", isCorrect: false },
+      ],
+    },
+    {
+      questionID: "2",
+      difficulty: 1,
+      resourceType: "Water",
+      text: "What percentage of the earth is covered in water?",
+      type: "MCQ",
+      choices: [
+        { text: "70", isCorrect: true },
+        { text: "30", isCorrect: false },
+        { text: "50", isCorrect: false },
+      ],
+    },
+  ] as WaterQuestion[]);
+  vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
+    const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
+    const correct = (array as RaindropAnswer[]).filter((a) => a.isCorrect);
+    return [...correct, ...incorrect];
+  });
+  vi.spyOn(Math, "random").mockReturnValue(0.4125);
+
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 800,
+  });
+
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter>
+      <WaterGame />
+    </MemoryRouter>,
+  );
+
+  await screen.findByTestId("water-start");
+  await user.click(screen.getByRole("button", { name: /play/i }));
+  await user.click(screen.getByRole("button", { name: /i'm ready/i }));
+
+  await screen.findByTestId("point-0", {}, { timeout: 5000 });
+
+  await waitFor(
+    () => {
+      expect(screen.queryByTestId("point-0")).not.toBeInTheDocument();
+    },
+    { timeout: 5000 },
+  );
+}, 15000);

--- a/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.game.test.tsx
@@ -3,9 +3,11 @@ Game Screen Integration Tests for the WaterGame Component
 
 This module contains integration tests for the game screen of the WaterGame
 component. These tests verify that the game screen components (question
-container, bucket, raindrops) render correctly, that the bucket moves
-correctly in response to arrow key presses, and that the end screen displays
-the correct results after the player catches a correct or incorrect raindrop.
+container, bucket, raindrops, point counter) render correctly, that the bucket 
+moves correctly in response to arrow key presses, the correct point indicator
+appears based on the raindrop caught, the point counter updates as questions 
+are answered, and that the end screen displays the correct results after the 
+player catches a correct or incorrect raindrop.
 */
 
 import { render, screen, waitFor } from "@testing-library/react";
@@ -16,12 +18,12 @@ import { vi, beforeEach, afterEach } from "vitest";
 import { WaterGame } from "../WaterGame";
 import styles from "../WaterGame.module.css";
 import type { RaindropAnswer } from "../types";
-import type { WaterQuestion } from "../../ServerCalls/ServerCalls";
+import type { Question } from "../../ServerCalls/ServerCalls";
 import * as ServerCalls from "../../ServerCalls/ServerCalls";
 import * as utils from "../utils";
 import { INCORRECT, NUM_POINTS } from "../constants";
 
-const mockWaterQuestions = [
+const mockQuestions = [
   {
     questionID: "1",
     difficulty: 1,
@@ -38,7 +40,7 @@ const mockWaterQuestions = [
 
 beforeEach(() => {
   vi.spyOn(ServerCalls, "fetchQuestions").mockResolvedValue(
-    mockWaterQuestions as WaterQuestion[],
+    mockQuestions as Question[],
   );
 });
 
@@ -295,7 +297,7 @@ test("displays correct point indicator when bucket catches correct raindrop", as
         { text: "50", isCorrect: false },
       ],
     },
-  ] as WaterQuestion[]);
+  ] as Question[]);
 
   vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
     const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
@@ -357,7 +359,7 @@ test("displays incorrect point indicator when bucket catches incorrect raindrop"
         { text: "50", isCorrect: false },
       ],
     },
-  ] as WaterQuestion[]);
+  ] as Question[]);
 
   vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
     const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
@@ -419,7 +421,7 @@ test("point indicator disappears after duration", async () => {
         { text: "50", isCorrect: false },
       ],
     },
-  ] as WaterQuestion[]);
+  ] as Question[]);
   vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
     const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
     const correct = (array as RaindropAnswer[]).filter((a) => a.isCorrect);
@@ -484,7 +486,7 @@ test("displays correct point count when bucket catches correct raindrop", async 
         { text: "50", isCorrect: false },
       ],
     },
-  ] as WaterQuestion[]);
+  ] as Question[]);
 
   vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
     const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);
@@ -546,7 +548,7 @@ test("displays correct point counter display when bucket catches incorrect raind
         { text: "50", isCorrect: false },
       ],
     },
-  ] as WaterQuestion[]);
+  ] as Question[]);
 
   vi.spyOn(utils, "shuffleArray").mockImplementation((array) => {
     const incorrect = (array as RaindropAnswer[]).filter((a) => !a.isCorrect);

--- a/client/src/pages/WaterGame/__tests__/WaterGame.navigation.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.navigation.test.tsx
@@ -165,7 +165,7 @@ test("renders results screen and game results", async () => {
     { timeout: 5000 },
   );
 
-  expect(screen.getByText(/game over/i)).toBeInTheDocument();
+  expect(screen.getByText(/good job/i)).toBeInTheDocument();
 
   const list = screen.getByRole("list");
   expect(list).toBeInTheDocument();

--- a/client/src/pages/WaterGame/__tests__/WaterGame.navigation.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.navigation.test.tsx
@@ -13,10 +13,10 @@ import { MemoryRouter } from "react-router-dom";
 import { vi, beforeEach, afterEach } from "vitest";
 
 import { WaterGame } from "../WaterGame";
-import type { WaterQuestion } from "../../ServerCalls/ServerCalls";
+import type { Question } from "../../ServerCalls/ServerCalls";
 import * as ServerCalls from "../../ServerCalls/ServerCalls";
 
-const mockWaterQuestions = [
+const mockQuestions = [
   {
     questionID: "1",
     difficulty: 1,
@@ -33,7 +33,7 @@ const mockWaterQuestions = [
 
 beforeEach(() => {
   vi.spyOn(ServerCalls, "fetchQuestions").mockResolvedValue(
-    mockWaterQuestions as WaterQuestion[],
+    mockQuestions as Question[],
   );
 });
 

--- a/client/src/pages/WaterGame/__tests__/WaterGame.questions.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.questions.test.tsx
@@ -13,10 +13,10 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { vi, beforeEach, afterEach } from "vitest";
 import { WaterGame } from "../WaterGame";
-import type { WaterQuestion } from "../../ServerCalls/ServerCalls";
+import type { Question } from "../../ServerCalls/ServerCalls";
 import * as ServerCalls from "../../ServerCalls/ServerCalls";
 
-const mockWaterQuestions = [
+const mockQuestions = [
   {
     questionID: "1",
     difficulty: 1,
@@ -46,7 +46,7 @@ const mockWaterQuestions = [
 
 beforeEach(() => {
   vi.spyOn(ServerCalls, "fetchQuestions").mockResolvedValue(
-    mockWaterQuestions as WaterQuestion[],
+    mockQuestions as Question[],
   );
 });
 
@@ -67,12 +67,12 @@ test("renders fetched question text on game screen", async () => {
   await user.click(screen.getByRole("button", { name: /i'm ready/i }));
 
   expect(screen.getByTestId("water-game")).toBeInTheDocument();
-  expect(screen.getByText(mockWaterQuestions[0].text)).toBeInTheDocument();
+  expect(screen.getByText(mockQuestions[0].text)).toBeInTheDocument();
 });
 
 test("shows loading indicator while questions are being fetched", async () => {
-  let resolveQuestions!: (value: WaterQuestion[]) => void;
-  const questionsPromise = new Promise<WaterQuestion[]>((resolve) => {
+  let resolveQuestions!: (value: Question[]) => void;
+  const questionsPromise = new Promise<Question[]>((resolve) => {
     resolveQuestions = resolve;
   });
 
@@ -86,7 +86,7 @@ test("shows loading indicator while questions are being fetched", async () => {
 
   expect(screen.getByText(/loading/i)).toBeInTheDocument();
 
-  resolveQuestions(mockWaterQuestions as WaterQuestion[]);
+  resolveQuestions(mockQuestions as Question[]);
   await waitFor(() => {
     expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
   });
@@ -116,11 +116,11 @@ test("question text updates after bucket catching raindrop", async () => {
   await user.click(screen.getByRole("button", { name: /play/i }));
   await user.click(screen.getByRole("button", { name: /i'm ready/i }));
 
-  expect(screen.getByText(mockWaterQuestions[0].text)).toBeInTheDocument();
+  expect(screen.getByText(mockQuestions[0].text)).toBeInTheDocument();
 
   await waitFor(
     () => {
-      expect(screen.getByText(mockWaterQuestions[1].text)).toBeInTheDocument();
+      expect(screen.getByText(mockQuestions[1].text)).toBeInTheDocument();
     },
     { timeout: 5000 },
   );

--- a/client/src/pages/WaterGame/__tests__/WaterGame.raindrop.test.tsx
+++ b/client/src/pages/WaterGame/__tests__/WaterGame.raindrop.test.tsx
@@ -17,11 +17,11 @@ import { vi, beforeEach, afterEach } from "vitest";
 
 import { WaterGame } from "../WaterGame";
 import { SPAWN_INTERVAL_MS, RAINDROP_WIDTH } from "../constants";
-import type { WaterQuestion } from "../../ServerCalls/ServerCalls";
+import type { Question } from "../../ServerCalls/ServerCalls";
 import * as ServerCalls from "../../ServerCalls/ServerCalls";
 import * as utils from "../utils";
 
-const mockWaterQuestions = [
+const mockQuestions = [
   {
     questionID: "1",
     difficulty: 1,
@@ -38,7 +38,7 @@ const mockWaterQuestions = [
 
 beforeEach(() => {
   vi.spyOn(ServerCalls, "fetchQuestions").mockResolvedValue(
-    mockWaterQuestions as WaterQuestion[],
+    mockQuestions as Question[],
   );
   Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
     configurable: true,

--- a/client/src/pages/WaterGame/components/Point.module.css
+++ b/client/src/pages/WaterGame/components/Point.module.css
@@ -9,7 +9,6 @@
 
 .pointText {
   text-align: center;
-  text-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
   font-family: Handjet;
   font-size: 64px;
   font-weight: 700;
@@ -21,7 +20,9 @@
     -2px -2px 0 #0e7600,
     2px -2px 0 #0e7600,
     -2px 2px 0 #0e7600,
-    2px 2px 0 #0e7600;
+    2px 2px 0 #0e7600,
+    0 4px 4px rgba(0, 0, 0, 0.6),
+    2px 6px 4px rgba(0, 0, 0, 0.6);
 }
 
 .incorrect {
@@ -30,5 +31,7 @@
     -2px -2px 0 #760000,
     2px -2px 0 #760000,
     -2px 2px 0 #760000,
-    2px 2px 0 #760000;
+    2px 2px 0 #760000,
+    0 4px 4px rgba(0, 0, 0, 0.6),
+    2px 6px 4px rgba(0, 0, 0, 0.6);
 }

--- a/client/src/pages/WaterGame/components/Point.module.css
+++ b/client/src/pages/WaterGame/components/Point.module.css
@@ -1,0 +1,34 @@
+.point {
+  display: flex;
+  width: 72px;
+  height: 72px;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+}
+
+.pointText {
+  text-align: center;
+  text-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+  font-family: Handjet;
+  font-size: 64px;
+  font-weight: 700;
+}
+
+.correct {
+  color: var(--color-success);
+  text-shadow:
+    -2px -2px 0 #0e7600,
+    2px -2px 0 #0e7600,
+    -2px 2px 0 #0e7600,
+    2px 2px 0 #0e7600;
+}
+
+.incorrect {
+  color: var(--color-incorrect);
+  text-shadow:
+    -2px -2px 0 #760000,
+    2px -2px 0 #760000,
+    -2px 2px 0 #760000,
+    2px 2px 0 #760000;
+}

--- a/client/src/pages/WaterGame/components/Point.tsx
+++ b/client/src/pages/WaterGame/components/Point.tsx
@@ -1,0 +1,24 @@
+import styles from "./Point.module.css";
+import { NUM_POINTS } from "../constants";
+import { INCORRECT } from "../constants";
+
+export type PointProps = {
+  id: number;
+  x: number;
+  y: number;
+  variant: "correct" | "incorrect";
+};
+
+export const Point = ({ id, x, y, variant }: PointProps) => {
+  return (
+    <div
+      className={styles.point}
+      data-testid={`point-${id}`}
+      style={{ left: x, top: y }}
+    >
+      <span className={`${styles.pointText} ${styles[variant]}`}>
+        {variant === "correct" ? `+${NUM_POINTS}` : INCORRECT}{" "}
+      </span>
+    </div>
+  );
+};

--- a/client/src/pages/WaterGame/components/Point.tsx
+++ b/client/src/pages/WaterGame/components/Point.tsx
@@ -1,3 +1,12 @@
+/*
+Point Component
+
+This component displays a score indicator when the player catches a raindrop
+with the bucket. It renders a "+" or "X" score text styled in green or red
+depending on whether the caught raindrop answer was correct or incorrect.
+The Point is positioned absolutely on the game screen above the bucket.
+*/
+
 import styles from "./Point.module.css";
 import { NUM_POINTS } from "../constants";
 import { INCORRECT } from "../constants";

--- a/client/src/pages/WaterGame/components/__tests__/Point.test.tsx
+++ b/client/src/pages/WaterGame/components/__tests__/Point.test.tsx
@@ -1,0 +1,74 @@
+/*
+Unit tests for the Point component
+
+This module contains unit tests for the Point component, which is a  
+component used throughout the water minigame.
+
+The tests verify that the Point component renders with the correct 
+styling class, text based on the variant, vertical position based on 
+the y property, and horizontal position based on the x property.
+*/
+
+import { test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Point } from "../Point";
+import styles from "../Point.module.css";
+import { NUM_POINTS, INCORRECT } from "../../constants";
+
+test("renders point component with styling for correct variant", () => {
+  render(<Point id={0} x={0} y={0} variant="correct" />);
+
+  const point = screen.getByTestId("point-0");
+  expect(point).toHaveClass(styles.point);
+
+  const pointSpan = point.querySelector("span");
+  expect(pointSpan).toHaveClass(styles.correct);
+  expect(pointSpan).toHaveTextContent(`+${NUM_POINTS}`);
+});
+
+test("renders point component with styling for incorrect variant", () => {
+  render(<Point id={0} x={0} y={0} variant="incorrect" />);
+
+  const point = screen.getByTestId("point-0");
+  expect(point).toHaveClass(styles.point);
+
+  const pointSpan = point.querySelector("span");
+  expect(pointSpan).toHaveClass(styles.incorrect);
+  expect(pointSpan).toHaveTextContent(`${INCORRECT}`);
+});
+
+test("sets left position based on x prop", () => {
+  render(<Point id={0} x={150} y={0} variant="correct" />);
+
+  const point = screen.getByTestId("point-0");
+  expect(point).toHaveStyle({ left: "150px" });
+});
+
+test("updates position when x prop changes", () => {
+  const { rerender } = render(<Point id={0} x={50} y={0} variant="correct" />);
+
+  let point = screen.getByTestId("point-0");
+  expect(point).toHaveStyle({ left: "50px" });
+
+  rerender(<Point id={0} x={200} y={0} variant="correct" />);
+  point = screen.getByTestId("point-0");
+  expect(point).toHaveStyle({ left: "200px" });
+});
+
+test("sets top position based on y prop", () => {
+  render(<Point id={0} x={0} y={150} variant="correct" />);
+
+  const point = screen.getByTestId("point-0");
+  expect(point).toHaveStyle({ top: "150px" });
+});
+
+test("updates position when y prop changes", () => {
+  const { rerender } = render(<Point id={0} x={0} y={50} variant="correct" />);
+
+  let point = screen.getByTestId("point-0");
+  expect(point).toHaveStyle({ top: "50px" });
+
+  rerender(<Point id={0} x={0} y={200} variant="correct" />);
+  point = screen.getByTestId("point-0");
+  expect(point).toHaveStyle({ top: "200px" });
+});

--- a/client/src/pages/WaterGame/constants.tsx
+++ b/client/src/pages/WaterGame/constants.tsx
@@ -5,3 +5,5 @@ export const SPAWN_INTERVAL_MS = 1750;
 export const BUCKET_WIDTH = 140;
 export const BUCKET_HEIGHT = 140;
 export const NUM_QUESTIONS = 3;
+export const NUM_POINTS = 10;
+export const INCORRECT = "X";

--- a/client/src/pages/WaterGame/constants.tsx
+++ b/client/src/pages/WaterGame/constants.tsx
@@ -1,11 +1,18 @@
-export const RAINDROP_WIDTH = 96; // 6rem
-export const RAINDROP_HEIGHT = 128; // 8rem
-export const RAINDROP_FALL_SPEED = 1.2;
-export const SPAWN_INTERVAL_MS = 1750;
+// Raindrop dimensions and movement
+export const RAINDROP_WIDTH = 96;
+export const RAINDROP_HEIGHT = 128;
+export const RAINDROP_FALL_SPEED = 1.2; // pixels per tick (tick = 16ms)
+export const SPAWN_INTERVAL_MS = 1750; // time between raindrop spawns in milliseconds
+
+// Bucket dimensions
 export const BUCKET_WIDTH = 140;
 export const BUCKET_HEIGHT = 140;
-export const NUM_QUESTIONS = 3;
-export const NUM_POINTS = 10;
-export const INCORRECT = "X";
-export const POINT_DURATION_MS = 2000;
-export const POINT_WIDTH = 72;
+
+// Game settings
+export const NUM_QUESTIONS = 3; // number of questions fetched per game session
+
+// Point indicator settings
+export const NUM_POINTS = 10; // points awarded per correct answer
+export const INCORRECT = "X"; // text displayed for an incorrect answer
+export const POINT_DURATION_MS = 2000; // time the point indicator remains on screen in milliseconds
+export const POINT_WIDTH = 72; // pixels, used to center the point indicator above the bucket

--- a/client/src/pages/WaterGame/constants.tsx
+++ b/client/src/pages/WaterGame/constants.tsx
@@ -7,3 +7,5 @@ export const BUCKET_HEIGHT = 140;
 export const NUM_QUESTIONS = 3;
 export const NUM_POINTS = 10;
 export const INCORRECT = "X";
+export const POINT_DURATION_MS = 2000;
+export const POINT_WIDTH = 72;

--- a/client/src/pages/WaterGame/hooks/useWaterGameQuestions.tsx
+++ b/client/src/pages/WaterGame/hooks/useWaterGameQuestions.tsx
@@ -8,24 +8,24 @@ Returns the fetched questions, a loading flag, and an error message if the fetch
 
 import { useState, useEffect } from "react";
 import { fetchQuestions } from "../../ServerCalls/ServerCalls";
-import type { WaterQuestion } from "../../ServerCalls/ServerCalls";
+import type { Question } from "../../ServerCalls/ServerCalls";
 import { NUM_QUESTIONS } from "../constants";
 
 interface UseWaterGameQuestionsResult {
-  questions: WaterQuestion[];
+  questions: Question[];
   isLoading: boolean;
   error: string | null;
 }
 
 export const useWaterGameQuestions = (): UseWaterGameQuestionsResult => {
-  const [questions, setQuestions] = useState<WaterQuestion[]>([]);
+  const [questions, setQuestions] = useState<Question[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const loadQuestions = async () => {
       try {
-        const fetched = await fetchQuestions("Water", NUM_QUESTIONS, "MCQ");
+        const fetched = await fetchQuestions(NUM_QUESTIONS, "Water", "MCQ");
         setQuestions(fetched);
       } catch {
         setError("Failed to load questions. Please try again.");

--- a/client/src/pages/WaterGame/types.tsx
+++ b/client/src/pages/WaterGame/types.tsx
@@ -11,3 +11,10 @@ export type RaindropData = {
   answer: string;
   isCorrect: boolean;
 };
+
+export type PointData = {
+  id: number;
+  x: number;
+  y: number;
+  variant: "correct" | "incorrect";
+};

--- a/client/src/pages/WaterGame/utils.tsx
+++ b/client/src/pages/WaterGame/utils.tsx
@@ -1,9 +1,9 @@
-import type { WaterQuestion } from "../ServerCalls/ServerCalls";
+import type { Question } from "../ServerCalls/ServerCalls";
 import type { RaindropAnswer } from "./types";
 
 // Converts a WaterQuestion's choices into the RaindropAnswer format used by the game
 export const questionToRaindropAnswers = (
-  question: WaterQuestion,
+  question: Question,
 ): RaindropAnswer[] => {
   return question.choices.map((choice) => ({
     text: choice.text,


### PR DESCRIPTION
## What

- Added point icons to denote whether the raindrop caught was correct/incorrect
- Added point counter in frontend so user can track progress
- Updated calls to server to use new Question type
- Added tests for appropriate point icons rendering depending on the answer
- Added tests for point counter incrementing/staying the same depending on the answer

## Why

- Promote user understanding of progress throughout the game
- Allow user to immediately know if they answered correctly/incorrectly

## How

- Worked independently

## Designs
<img width="1440" height="1024" alt="correctanswer" src="https://github.com/user-attachments/assets/16da9ae3-e23b-4a61-8731-659a27b8af79" />



## Test Steps

- [] if haven't created database, `cd server` and run `python -m Database.createDatabase`  
- [] if haven't added default questions to database, `cd ..` and run `python -m utils.addDefaultQuestions`
- [] boot up backend and start frontend
- [] check that UI reflects appropriate behavior
- run `npm run test` in client directory
