### PR TITLE
Fixed Bug With Account Settings

### DIFF
--- a/client/src/pages/AccountSettings/AccountSettings.test.tsx
+++ b/client/src/pages/AccountSettings/AccountSettings.test.tsx
@@ -61,7 +61,7 @@ describe('AccountSettings', () => {
         expect(screen.getByText('ACCOUNT SETTINGS')).toBeInTheDocument();
         expect(screen.getByText('Name:')).toBeInTheDocument();
         expect(screen.getByText('Contact Email:')).toBeInTheDocument();
-        expect(screen.getByText('3-6')).toBeInTheDocument();
+        expect(screen.getByText('1')).toBeInTheDocument();
     });
 
     it('navigates home when the home button is clicked', async () => {

--- a/client/src/pages/AccountSettings/AccountSettings.tsx
+++ b/client/src/pages/AccountSettings/AccountSettings.tsx
@@ -18,7 +18,7 @@ import {
     updateAccountProfile,
 } from '../ServerCalls/ServerCalls';
 
-const EDUCATION_LEVELS = ['3-6', '6-8', '9-12'] as const;
+const EDUCATION_LEVELS = Array.from({ length: 12 }, (_, i) => i + 1) as const;
 const DEFAULT_EDUCATION_LEVEL = EDUCATION_LEVELS[0];
 
 const isValidOptionalEmail = (value: string) => {

--- a/client/src/pages/AccountSettings/AccountSettingsEdit.test.tsx
+++ b/client/src/pages/AccountSettings/AccountSettingsEdit.test.tsx
@@ -59,7 +59,7 @@ describe('AccountSettingsEdit', () => {
         expect(screen.getByText('ACCOUNT SETTINGS')).toBeInTheDocument();
         expect(screen.getByLabelText('Name:')).toHaveValue('Ada Lovelace');
         expect(screen.getByLabelText('Contact Email:')).toHaveValue('');
-        expect(screen.getByLabelText('Education Level:')).toHaveValue('3-6');
+        expect(screen.getByLabelText('Education Level:')).toHaveValue('1');
     });
 
     it('saves values and navigates back to account', async () => {

--- a/server/api/__test__/usersUnitTest.py
+++ b/server/api/__test__/usersUnitTest.py
@@ -348,7 +348,7 @@ class TestUpdateUser(unittest.TestCase):
                                 "displayName": "Updated Student",
                                 "roles": [settings.ROLE_STUDENT]
                             }
-                            mock_get_student_details.return_value = {"studentLevel": "6-8"}
+                            mock_get_student_details.return_value = {"studentLevel": 2}
                             
                             app = create_test_app(user_data=self.mock_student)
                             from api.routers.users import router
@@ -362,7 +362,7 @@ class TestUpdateUser(unittest.TestCase):
                                 "email": "student@example.com",
                                 "roles": [settings.ROLE_STUDENT],
                                 "contactEmail": "contact@example.com",
-                                "educationLevel": "6-8"
+                                "educationLevel": 2
                             }
                             
                             response = client.put("/api/update-user", json=update_payload)
@@ -402,7 +402,7 @@ class TestUpdateUser(unittest.TestCase):
                                 "email": "new@example.com",
                                 "roles": [settings.ROLE_STUDENT],
                                 "contactEmail": "contact@example.com",
-                                "educationLevel": "6-8"
+                                "educationLevel": 2
                             })
                             
                             # Verify update functions were called
@@ -540,7 +540,7 @@ class TestUpdateUser(unittest.TestCase):
         with patch('api.routers.users.TreeService') as mock_tree_service:
             with patch('api.routers.users.get_student_details') as mock_get_student_details:
                 mock_tree_service.get_tree_with_decay.return_value = self.mock_tree
-                mock_get_student_details.return_value = {"contactEmail": "parent@example.com", "studentLevel": "6-8"}
+                mock_get_student_details.return_value = {"contactEmail": "parent@example.com", "studentLevel": 2}
                 
                 app = create_test_app(user_data=self.mock_student)
                 from api.routers.users import router

--- a/server/api/__test__/usersUnitTest.py
+++ b/server/api/__test__/usersUnitTest.py
@@ -472,7 +472,7 @@ class TestUpdateUser(unittest.TestCase):
                                 "displayName": "Updated",
                                 "roles": [settings.ROLE_STUDENT]
                             }
-                            mock_get_student_details.return_value = {"studentLevel": "9-10"}
+                            mock_get_student_details.return_value = {"studentLevel": 5}
                             
                             app = create_test_app(user_data=self.mock_student)
                             from api.routers.users import router

--- a/server/api/routers/users.py
+++ b/server/api/routers/users.py
@@ -27,7 +27,7 @@ def get_user_info(request: Request, student=Depends(student_required)):
             "email": "student@example.com",
             "roles": ["Student"],
             "contactEmail": "parent@example.com",
-            "educationLevel": "6-8"
+            "educationLevel": "2"
         },
         "tree": {
             "treeID": "uuid-string",
@@ -96,7 +96,7 @@ async def update_user(
         "displayName": "New Name",
         "roles": ["Student"],
         "contactEmail": "contact@example.com",
-        "educationLevel": "6-8"
+        "educationLevel": 2
     }
     
     Returns:

--- a/server/api/routers/users.py
+++ b/server/api/routers/users.py
@@ -58,7 +58,7 @@ def get_user_info(request: Request, student=Depends(student_required)):
         displayName=student.get("displayName"),
         roles=student.get("roles", []),
         contactEmail=student_details.get("contactEmail") if student_details else None,
-        educationLevel=str(student_details.get("studentLevel")) if student_details and student_details.get("studentLevel") else None,
+        educationLevel=student_details.get("studentLevel") if student_details and student_details.get("studentLevel") else None,
     )
     
     # Construct TreeInfo object if tree exists
@@ -151,7 +151,7 @@ async def update_user(
             displayName=user_update.displayName or account_data.get("displayName", ""),
             roles=account_data.get("roles", []),
             contactEmail=updated_student_details.get("contactEmail") if updated_student_details else None,
-            educationLevel=str(updated_student_details.get("studentLevel")) if updated_student_details and updated_student_details.get("studentLevel") else None,
+            educationLevel=updated_student_details.get("studentLevel") if updated_student_details and updated_student_details.get("studentLevel") else None,
         )
         
         # Construct TreeInfo if tree exists

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -140,17 +140,9 @@ class Settings:
     ]
 
     # ========== EDUCATION LEVELS ==========
-    # Maps education level labels to integer codes for storage
-    EDUCATION_LEVEL_PRIMARY: str = "3-6"
-    EDUCATION_LEVEL_MIDDLE: str = "6-8"
-    EDUCATION_LEVEL_HIGH: str = "9-12"
-    
-    EDUCATION_LEVEL_LABEL_TO_CODE: Dict[str, int] = {
-        "3-6": 1,
-        "6-8": 2,
-        "9-12": 3,
-    }
-    DEFAULT_EDUCATION_LEVEL_CODE: int = 1  # '3-6'
+    # Supported education levels: grades 1-12
+    VALID_EDUCATION_LEVELS: List[int] = list(range(1, 13))  # 1-12
+    DEFAULT_EDUCATION_LEVEL_CODE: int = 1  # Grade 1
     
     # ========== TIMING & DECAY ==========
     # Passive decay rates for resources -- how many minutes to decay 1 level of the resource

--- a/server/database/addItemsToDatabase.py
+++ b/server/database/addItemsToDatabase.py
@@ -35,7 +35,7 @@ import uuid
 
 # Import education level constants for student details
 DEFAULT_EDUCATION_LEVEL_CODE = settings.DEFAULT_EDUCATION_LEVEL_CODE
-EDUCATION_LEVEL_LABEL_TO_CODE = settings.EDUCATION_LEVEL_LABEL_TO_CODE
+VALID_EDUCATION_LEVELS = settings.VALID_EDUCATION_LEVELS
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DB_PATH = os.path.join(BASE_DIR, settings.DB_NAME)
@@ -512,18 +512,28 @@ def join_class(student_username: str, class_code: str):
     _execute(sql, (student_username, class_id))
 
 def _normalize_education_level_code(value: int | str | None) -> int:
+    """
+    Normalize education level to an integer code (1-12).
+    
+    Args:
+        value: Can be an integer (1-12), string representation of integer, or None
+        
+    Returns:
+        Integer between 1 and 12
+        
+    Raises:
+        ValueError: If value is not a valid education level
+    """
     if value is None:
         return DEFAULT_EDUCATION_LEVEL_CODE
     if isinstance(value, int):
-        if value in EDUCATION_LEVEL_LABEL_TO_CODE.values():
+        if value in VALID_EDUCATION_LEVELS:
             return value
-        raise ValueError(f"Invalid education level code: {value}")
+        raise ValueError(f"Invalid education level code: {value}. Must be between 1 and 12.")
     trimmed = value.strip()
     if trimmed.isdigit():
         return _normalize_education_level_code(int(trimmed))
-    if trimmed in EDUCATION_LEVEL_LABEL_TO_CODE:
-        return EDUCATION_LEVEL_LABEL_TO_CODE[trimmed]
-    raise ValueError(f"Invalid education level label: {value}")
+    raise ValueError(f"Invalid education level: {value}. Must be a number between 1 and 12.")
 
 
 def upsert_student_details(student_username: str, contact_email: str | None = None, education_level: int | str | None = None):

--- a/server/integration_tests/apiIntegrationTest.py
+++ b/server/integration_tests/apiIntegrationTest.py
@@ -370,7 +370,7 @@ class APIIntegrationTests(unittest.TestCase):
             "displayName": "Updated Test User",
             "roles": current_user.get("roles", [settings.ROLE_STUDENT]),
             "contactEmail": "contact@example.com",
-            "educationLevel": "6-8",
+            "educationLevel": 2,
         }
         response = self.client.put("/api/update-user", json=update_data)
         

--- a/server/regression_tests/apiUserRegressionTests.py
+++ b/server/regression_tests/apiUserRegressionTests.py
@@ -209,7 +209,7 @@ class TestUserAPIRoutes(APIQuestionsTestCase):
         self.assertEqual(updated_user["displayName"], "Updated Student")
         self.assertEqual(updated_user["email"], "updated@example.com")
         self.assertEqual(updated_user["contactEmail"], "contact@example.com")
-        self.assertEqual(updated_user["educationLevel"], "2")
+        self.assertEqual(updated_user["educationLevel"], 2)
 
         # Verify persistence in database
         person = get_person("test_student@example.com")

--- a/server/regression_tests/apiUserRegressionTests.py
+++ b/server/regression_tests/apiUserRegressionTests.py
@@ -198,7 +198,7 @@ class TestUserAPIRoutes(APIQuestionsTestCase):
             "email": "updated@example.com",
             "roles": ["Student"],
             "contactEmail": "contact@example.com",
-            "educationLevel": "6-8",
+            "educationLevel": 2,
         }
         response = client.put("/api/update-user", json=update_payload)
         self.assertEqual(response.status_code, 200)

--- a/server/regression_tests/databaseInteractRegressionTests.py
+++ b/server/regression_tests/databaseInteractRegressionTests.py
@@ -579,7 +579,7 @@ class TestStudentDetails(DatabaseInteractTestCase):
         upsert_student_details(
             student_username="student_detail_user",
             contact_email="parent@example.com",
-            education_level="3-6"
+            education_level=1
         )
 
         result = get_student_details("student_detail_user")
@@ -593,13 +593,13 @@ class TestStudentDetails(DatabaseInteractTestCase):
         upsert_student_details(
             student_username="student_detail_user",
             contact_email="old@example.com",
-            education_level="3-6"
+            education_level=1
         )
 
         upsert_student_details(
             student_username="student_detail_user",
             contact_email="new@example.com",
-            education_level="6-8"
+            education_level=2
         )
 
         result = get_student_details("student_detail_user")
@@ -624,7 +624,7 @@ class TestIntegration(DatabaseInteractTestCase):
         )
         
         # Add student details
-        upsert_student_details("john_student", education_level="3-6")
+        upsert_student_details("john_student", education_level=1)
         
         # Generate tree
         tree_id = generate_tree("john_student")

--- a/server/schemas/user.py
+++ b/server/schemas/user.py
@@ -14,7 +14,7 @@ class UserInfo(BaseModel):
     displayName: str
     roles: List[str]
     contactEmail: Optional[str] = None
-    educationLevel: Optional[str] = None
+    educationLevel: Optional[int] = None
 
 
 class UserUpdate(BaseModel):
@@ -22,7 +22,7 @@ class UserUpdate(BaseModel):
     email: Optional[EmailStr] = None
     displayName: Optional[str] = None
     contactEmail: Optional[str] = None
-    educationLevel: Optional[str] = None
+    educationLevel: Optional[int] = None
 
 
 class UserWithTree(BaseModel):


### PR DESCRIPTION
## What:
- Converted over to using integers from 1-12 for education level.
- Ensured backend fully supported this.

## Why:
- Ranges made less sense and we were having inconsistent behavior

## Checklist:
- [ ] Run tests (python -m unittest discover -s . -p "*UnitTest.py" -v )
- [ ] Run ./start.sh and try it out. Currently education level doesn't have a purpose so the main focus is that no functionality breaks and that everything looks as expected.