### PR TITLE
Fixed email notifications after passing thresholds.

### DIFF
--- a/server/database/addItemsToDatabase.py
+++ b/server/database/addItemsToDatabase.py
@@ -20,6 +20,7 @@ Functions - Tree & Resource Management:
     generate_tree(username)
     update_stat(tree_ID, stat_name, value)
     update_health(tree_ID, health_status)  # Updates the overall health status of the tree (healthy, unhealthy, etc.)
+    add_event(event)  # Records an event in the database
     do_event(tree_ID, event, value)
 
 Functions - Class Management:
@@ -243,6 +244,53 @@ def add_question_choice(choice_id: str, question_id: str, text: str, is_correct:
     '''
     
     _execute(sql, (choice_id, question_id, text, 1 if is_correct else 0))
+
+
+def add_event(event: Event) -> str:
+    """
+    Add an event to the Event table in the database.
+    
+    Args:
+        event: Event object to store in the database
+    
+    Returns:
+        str: The eventID of the added event
+    
+    Raises:
+        ValueError: If eventType or resourceAffected is invalid
+        sqlite3.IntegrityError: If eventID already exists (PRIMARY KEY violation)
+    
+    Note:
+        This function only records the event in the database.
+        To apply event effects to a tree, use do_event() instead.
+        The resourceAffected is automatically converted to lowercase to match database constraints.
+    """
+    if event.eventType not in settings.VALID_EVENT_TYPES:
+        raise ValueError(f"Invalid event type '{event.eventType}'. Must be one of {settings.VALID_EVENT_TYPES}")
+    
+    # Convert resourceAffected to lowercase for database constraint compatibility
+    resource_value = event.resourceAffected.lower() if event.resourceAffected else None
+    
+    # Validate resourceAffected (case-insensitive)
+    if resource_value and resource_value not in settings.VALID_RESOURCES:
+        raise ValueError(f"Invalid resource '{event.resourceAffected}'. Must be one of {settings.VALID_RESOURCES} (case-insensitive)")
+    
+    sql = '''
+        INSERT INTO Event (eventID, eventType, resourceAffected, description, percentChange, conditions)
+        VALUES (?, ?, ?, ?, ?, ?)
+    '''
+    
+    _execute(sql, (
+        event.eventID,
+        event.eventType,
+        resource_value,  # Store as lowercase
+        event.description,
+        event.percentChange,
+        event.conditions
+    ))
+    
+    return event.eventID
+
 
 def apply_passive_decay(tree_ID: str):
     """

--- a/server/database/createDatabase.py
+++ b/server/database/createDatabase.py
@@ -107,7 +107,7 @@ def create_schema(db_path=DB_PATH):
     cursor.execute(f'''
     CREATE TABLE IF NOT EXISTS Event (
         eventID TEXT PRIMARY KEY,
-        eventType TEXT NOT NULL CHECK(eventType IN ('{settings.EVENT_LEVEL}', '{settings.EVENT_BONUS}', '{settings.EVENT_PENALTY}', '{settings.EVENT_NEUTRAL}')),
+        eventType TEXT NOT NULL CHECK(eventType IN ('{settings.EVENT_LEVEL}', '{settings.EVENT_BONUS}', '{settings.EVENT_PENALTY}', '{settings.EVENT_NEUTRAL}', '{settings.EVENT_CHANGE}')),
         resourceAffected TEXT CHECK(resourceAffected IN ('{settings.RESOURCE_WATER}', '{settings.RESOURCE_EARTH}', '{settings.RESOURCE_SUN}', '{settings.RESOURCE_NONE}', '{settings.RESOURCE_ALL}')),
         description TEXT,
         percentChange INTEGER,

--- a/server/schemas/__init__.py
+++ b/server/schemas/__init__.py
@@ -9,7 +9,7 @@ from schemas.question import (
     QuestionResponse,
     QuestionsGetRequest
 )
-from schemas.event import Event, EventType, Resource, DUMMY_EVENT
+from schemas.event import Event, EventType, Resource
 
 # Rebuild models to resolve forward references
 UserWithTree.model_rebuild()
@@ -49,7 +49,6 @@ __all__ = [
     "Event",
     "EventType",
     "Resource",
-    "DUMMY_EVENT",
     "GenericResponse",
     "DataResponse",
     "QuestionListResponse",

--- a/server/schemas/event.py
+++ b/server/schemas/event.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from typing import Literal, Optional
 
-EventType = Literal["Decay", "Bonus", "Penalty"]
+EventType = Literal["Decay", "Bonus", "Penalty", "Change"]
 Resource = Literal["Water", "Earth", "Sun", "None", "All"]
 
 
@@ -14,14 +14,3 @@ class Event:
     description: Optional[str]
     percentChange: int
     conditions: Optional[str]
-
-
-# Simple dummy event for testing/demo usage.
-DUMMY_EVENT = Event(
-    eventID="dummy-event-001",
-    eventType="Bonus",
-    resourceAffected="Water",
-    description="Test event for local development.",
-    percentChange=10,
-    conditions="None"
-)

--- a/server/services/__test__/notificationServiceUnitTest.py
+++ b/server/services/__test__/notificationServiceUnitTest.py
@@ -1,0 +1,316 @@
+"""Unit tests for the NotificationService."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+from services.notification_service import NotificationService
+from schemas import Event
+from config.settings import settings
+
+
+class TestNotificationService(unittest.TestCase):
+    """Test cases for NotificationService threshold checking and notifications."""
+    
+    def test_get_threshold_status_water_healthy(self):
+        """Test water resource at healthy level."""
+        status = NotificationService._get_threshold_status('water', 75)
+        self.assertEqual(status, settings.HEALTH_HEALTHY)
+    
+    def test_get_threshold_status_water_unhealthy(self):
+        """Test water resource at unhealthy level."""
+        status = NotificationService._get_threshold_status('water', 50)
+        self.assertEqual(status, settings.HEALTH_UNHEALTHY)
+    
+    def test_get_threshold_status_water_withered(self):
+        """Test water resource at withered level."""
+        status = NotificationService._get_threshold_status('water', 30)
+        self.assertEqual(status, settings.HEALTH_WITHERED)
+    
+    def test_get_threshold_status_water_at_threshold(self):
+        """Test water resource exactly at threshold boundary."""
+        # At 70, should be healthy (>= TREE_HEALTH_THRESHOLD)
+        status = NotificationService._get_threshold_status('water', 70)
+        self.assertEqual(status, settings.HEALTH_HEALTHY)
+        
+        # At 69, should be unhealthy (< TREE_HEALTH_THRESHOLD)
+        status = NotificationService._get_threshold_status('water', 69)
+        self.assertEqual(status, settings.HEALTH_UNHEALTHY)
+        
+        # At 40, should be unhealthy (>= TREE_UNHEALTHY_THRESHOLD)
+        status = NotificationService._get_threshold_status('water', 40)
+        self.assertEqual(status, settings.HEALTH_UNHEALTHY)
+        
+        # At 39, should be withered (< TREE_UNHEALTHY_THRESHOLD)
+        status = NotificationService._get_threshold_status('water', 39)
+        self.assertEqual(status, settings.HEALTH_WITHERED)
+    
+    def test_get_threshold_status_earth_healthy(self):
+        """Test earth resource at healthy level."""
+        status = NotificationService._get_threshold_status('earth', 80)
+        self.assertEqual(status, settings.HEALTH_HEALTHY)
+    
+    def test_get_threshold_status_earth_unhealthy(self):
+        """Test earth resource at unhealthy level."""
+        status = NotificationService._get_threshold_status('earth', 50)
+        self.assertEqual(status, settings.HEALTH_UNHEALTHY)
+    
+    def test_get_threshold_status_earth_withered(self):
+        """Test earth resource at withered level."""
+        status = NotificationService._get_threshold_status('earth', 30)
+        self.assertEqual(status, settings.HEALTH_WITHERED)
+    
+    def test_get_threshold_status_earth_at_threshold(self):
+        """Test earth resource exactly at threshold boundary."""
+        # At 75, should be healthy (>= EARTH_HEALTH_THRESHOLD)
+        status = NotificationService._get_threshold_status('earth', 75)
+        self.assertEqual(status, settings.HEALTH_HEALTHY)
+        
+        # At 74, should be unhealthy (< EARTH_HEALTH_THRESHOLD)
+        status = NotificationService._get_threshold_status('earth', 74)
+        self.assertEqual(status, settings.HEALTH_UNHEALTHY)
+        
+        # At 45, should be unhealthy (>= EARTH_UNHEALTHY_THRESHOLD)
+        status = NotificationService._get_threshold_status('earth', 45)
+        self.assertEqual(status, settings.HEALTH_UNHEALTHY)
+        
+        # At 44, should be withered (< EARTH_UNHEALTHY_THRESHOLD)
+        status = NotificationService._get_threshold_status('earth', 44)
+        self.assertEqual(status, settings.HEALTH_WITHERED)
+    
+    def test_has_crossed_threshold_no_crossing(self):
+        """Test when no threshold is crossed."""
+        # No crossing when staying in same status
+        result = NotificationService._has_crossed_threshold(80, 75, 'water')
+        self.assertIsNone(result)
+        
+        # No crossing when improving
+        result = NotificationService._has_crossed_threshold(30, 50, 'water')
+        self.assertIsNone(result)
+    
+    def test_has_crossed_threshold_healthy_to_unhealthy(self):
+        """Test crossing from healthy to unhealthy."""
+        result = NotificationService._has_crossed_threshold(75, 65, 'water')
+        self.assertEqual(result, settings.HEALTH_UNHEALTHY)
+    
+    def test_has_crossed_threshold_unhealthy_to_withered(self):
+        """Test crossing from unhealthy to withered."""
+        result = NotificationService._has_crossed_threshold(50, 35, 'water')
+        self.assertEqual(result, settings.HEALTH_WITHERED)
+    
+    def test_has_crossed_threshold_healthy_to_withered(self):
+        """Test crossing from healthy directly to withered."""
+        result = NotificationService._has_crossed_threshold(80, 30, 'water')
+        self.assertEqual(result, settings.HEALTH_WITHERED)
+    
+    def test_has_crossed_threshold_improvement_ignored(self):
+        """Test that improvements don't trigger notifications."""
+        # Withered to unhealthy (improvement)
+        result = NotificationService._has_crossed_threshold(30, 50, 'water')
+        self.assertIsNone(result)
+        
+        # Unhealthy to healthy (improvement)
+        result = NotificationService._has_crossed_threshold(60, 75, 'water')
+        self.assertIsNone(result)
+    
+    @patch('services.notification_service.get_student_details')
+    def test_get_user_contact_email_success(self, mock_get_student):
+        """Test retrieving contact email successfully."""
+        mock_get_student.return_value = {
+            'studentUsername': 'testuser',
+            'contactEmail': 'test@example.com'
+        }
+        
+        email = NotificationService._get_user_contact_email('testuser')
+        self.assertEqual(email, 'test@example.com')
+        mock_get_student.assert_called_once_with('testuser')
+    
+    @patch('services.notification_service.get_student_details')
+    def test_get_user_contact_email_no_email(self, mock_get_student):
+        """Test when user has no contact email set."""
+        mock_get_student.return_value = {
+            'studentUsername': 'testuser',
+            'contactEmail': None
+        }
+        
+        email = NotificationService._get_user_contact_email('testuser')
+        self.assertIsNone(email)
+    
+    @patch('services.notification_service.get_student_details')
+    def test_get_user_contact_email_no_student_details(self, mock_get_student):
+        """Test when user has no student details."""
+        mock_get_student.return_value = None
+        
+        email = NotificationService._get_user_contact_email('testuser')
+        self.assertIsNone(email)
+    
+    @patch('services.notification_service.add_event')
+    def test_create_threshold_event_withered(self, mock_add_event):
+        """Test creating event for withered status."""
+        event = NotificationService._create_threshold_event('water', settings.HEALTH_WITHERED, 30)
+        
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.eventType, settings.EVENT_CHANGE)
+        self.assertEqual(event.resourceAffected, 'Water')
+        self.assertIn('CRITICAL', event.description)
+        self.assertIn('Withered', event.description)
+        self.assertIn('30%', event.description)
+        
+        # Verify event was added to database
+        mock_add_event.assert_called_once_with(event)
+    
+    @patch('services.notification_service.add_event')
+    def test_create_threshold_event_unhealthy(self, mock_add_event):
+        """Test creating event for unhealthy status."""
+        event = NotificationService._create_threshold_event('earth', settings.HEALTH_UNHEALTHY, 50)
+        
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.eventType, settings.EVENT_CHANGE)
+        self.assertEqual(event.resourceAffected, 'Earth')
+        self.assertIn('WARNING', event.description)
+        self.assertIn('Unhealthy', event.description)
+        self.assertIn('50%', event.description)
+        
+        # Verify event was added to database
+        mock_add_event.assert_called_once_with(event)
+    
+    @patch('services.notification_service.add_event')
+    def test_create_threshold_event_unique_ids(self, mock_add_event):
+        """Test that multiple events generate unique eventIDs."""
+        event1 = NotificationService._create_threshold_event('water', settings.HEALTH_WITHERED, 30)
+        event2 = NotificationService._create_threshold_event('water', settings.HEALTH_WITHERED, 30)
+        event3 = NotificationService._create_threshold_event('earth', settings.HEALTH_UNHEALTHY, 50)
+        
+        # All eventIDs should be unique (required for PRIMARY KEY in database)
+        self.assertNotEqual(event1.eventID, event2.eventID)
+        self.assertNotEqual(event1.eventID, event3.eventID)
+        self.assertNotEqual(event2.eventID, event3.eventID)
+        
+        # Verify they are valid UUIDs
+        import uuid
+        try:
+            uuid.UUID(event1.eventID)
+            uuid.UUID(event2.eventID)
+            uuid.UUID(event3.eventID)
+        except ValueError:
+            self.fail("eventID should be a valid UUID")
+    
+    @patch('services.notification_service.add_event')
+    def test_create_threshold_event_database_failure(self, mock_add_event):
+        """Test that event creation continues even if database insertion fails."""
+        mock_add_event.side_effect = Exception("Database error")
+        
+        # Should not raise exception, just log warning
+        event = NotificationService._create_threshold_event('water', settings.HEALTH_WITHERED, 30)
+        
+        # Event should still be created
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.eventType, settings.EVENT_CHANGE)
+        
+        # add_event should have been attempted
+        mock_add_event.assert_called_once()
+    
+    @patch('services.notification_service.add_event')
+    @patch('services.notification_service.EmailService.send_event_notification')
+    @patch('services.notification_service.get_student_details')
+    def test_check_and_notify_threshold_success(self, mock_get_student, mock_send_email, mock_add_event):
+        """Test successful threshold notification."""
+        mock_get_student.return_value = {
+            'contactEmail': 'test@example.com'
+        }
+        mock_send_email.return_value = True
+        
+        # Crossing from healthy to unhealthy
+        result = NotificationService.check_and_notify_threshold(
+            username='testuser',
+            tree_id='tree-123',
+            resource_name='water',
+            old_value=75,
+            new_value=65
+        )
+        
+        self.assertTrue(result)
+        mock_send_email.assert_called_once()
+        
+        # Verify event details
+        call_args = mock_send_email.call_args
+        sent_email = call_args[0][0]
+        sent_event = call_args[0][1]
+        
+        self.assertEqual(sent_email, 'test@example.com')
+        self.assertIsInstance(sent_event, Event)
+        self.assertEqual(sent_event.resourceAffected, 'Water')
+    
+    @patch('services.notification_service.get_student_details')
+    def test_check_and_notify_threshold_no_threshold_crossed(self, mock_get_student):
+        """Test when no threshold is crossed."""
+        result = NotificationService.check_and_notify_threshold(
+            username='testuser',
+            tree_id='tree-123',
+            resource_name='water',
+            old_value=75,
+            new_value=73
+        )
+        
+        self.assertFalse(result)
+        # Should not even check for email
+        mock_get_student.assert_not_called()
+    
+    @patch('services.notification_service.add_event')
+    @patch('services.notification_service.get_student_details')
+    def test_check_and_notify_threshold_no_contact_email(self, mock_get_student, mock_add_event):
+        """Test when user has no contact email."""
+        mock_get_student.return_value = None
+        
+        result = NotificationService.check_and_notify_threshold(
+            username='testuser',
+            tree_id='tree-123',
+            resource_name='water',
+            old_value=75,
+            new_value=65
+        )
+        
+        self.assertFalse(result)
+    
+    @patch('services.notification_service.add_event')
+    @patch('services.notification_service.EmailService.send_event_notification')
+    @patch('services.notification_service.get_student_details')
+    def test_check_and_notify_threshold_email_failure(self, mock_get_student, mock_send_email, mock_add_event):
+        """Test when email sending fails."""
+        mock_get_student.return_value = {
+            'contactEmail': 'test@example.com'
+        }
+        mock_send_email.return_value = False
+        
+        result = NotificationService.check_and_notify_threshold(
+            username='testuser',
+            tree_id='tree-123',
+            resource_name='water',
+            old_value=75,
+            new_value=65
+        )
+        
+        self.assertFalse(result)
+    
+    @patch('services.notification_service.add_event')
+    @patch('services.notification_service.EmailService.send_event_notification')
+    @patch('services.notification_service.get_student_details')
+    def test_check_and_notify_threshold_exception_handling(self, mock_get_student, mock_send_email, mock_add_event):
+        """Test exception handling during notification."""
+        mock_get_student.return_value = {
+            'contactEmail': 'test@example.com'
+        }
+        mock_send_email.side_effect = Exception("SMTP error")
+        
+        # Should not raise exception, just log and return False
+        result = NotificationService.check_and_notify_threshold(
+            username='testuser',
+            tree_id='tree-123',
+            resource_name='water',
+            old_value=75,
+            new_value=65
+        )
+        
+        self.assertFalse(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/services/__test__/treeServiceUnitTest.py
+++ b/server/services/__test__/treeServiceUnitTest.py
@@ -60,6 +60,50 @@ class TestTreeService(unittest.TestCase):
 
         mock_apply_decay.assert_called_once_with("tree-uuid-123")
 
+    @patch("services.tree_service.NotificationService.check_and_notify_threshold")
+    @patch("services.tree_service.apply_passive_decay")
+    @patch("services.tree_service._query")
+    def test_apply_decay_triggers_threshold_check_on_passive_change(
+        self,
+        mock_query,
+        mock_apply_decay,
+        mock_check_threshold,
+    ):
+        """Test passive decay triggers notification checks when resource levels change."""
+        mock_apply_decay.return_value = True
+        mock_query.side_effect = [
+            {
+                "ownerUsername": "student@example.com",
+                settings.RESOURCE_WATER: 80,
+                settings.RESOURCE_EARTH: 70,
+                settings.RESOURCE_SUN: 60,
+            },
+            {
+                "ownerUsername": "student@example.com",
+                settings.RESOURCE_WATER: 75,
+                settings.RESOURCE_EARTH: 70,
+                settings.RESOURCE_SUN: 55,
+            },
+        ]
+
+        TreeService.apply_decay("tree-uuid-123")
+
+        self.assertEqual(mock_check_threshold.call_count, 2)
+        mock_check_threshold.assert_any_call(
+            username="student@example.com",
+            tree_id="tree-uuid-123",
+            resource_name=settings.RESOURCE_WATER,
+            old_value=80,
+            new_value=75,
+        )
+        mock_check_threshold.assert_any_call(
+            username="student@example.com",
+            tree_id="tree-uuid-123",
+            resource_name=settings.RESOURCE_SUN,
+            old_value=60,
+            new_value=55,
+        )
+
     @patch("services.tree_service.apply_passive_decay")
     @patch("services.tree_service.get_all_trees")
     def test_apply_decay_to_all_counts_successes(self, mock_get_all_trees, mock_apply_decay):

--- a/server/services/notification_service.py
+++ b/server/services/notification_service.py
@@ -1,0 +1,188 @@
+"""
+Notification Service for Tree Health Alerts
+
+This service manages email notifications when tree resources fall below defined thresholds.
+It integrates EmailService with tree resource monitoring to alert users about critical tree health.
+"""
+
+import uuid
+from typing import Optional, Dict
+from schemas import Event
+from utils.email import EmailService
+from config.settings import settings
+from database.getItemsFromDatabase import get_student_details, get_tree
+from database.addItemsToDatabase import add_event
+
+
+class NotificationService:
+    """
+    Handles threshold-based email notifications for tree health alerts.
+    
+    This service monitors tree resource levels (water, earth) and sends email
+    notifications to users when their tree crosses critical health thresholds.
+    """
+    
+    @staticmethod
+    def _get_threshold_status(resource_name: str, level: int) -> str:
+        """
+        Determine the health status based on resource level and thresholds.
+        
+        Args:
+            resource_name: The resource type ('water' or 'earth')
+            level: The current resource level (0-100)
+            
+        Returns:
+            str: Health status ('Healthy', 'Unhealthy', or 'Withered')
+        """
+        if resource_name == settings.RESOURCE_WATER:
+            if level >= settings.TREE_HEALTH_THRESHOLD:
+                return settings.HEALTH_HEALTHY
+            elif level >= settings.TREE_UNHEALTHY_THRESHOLD:
+                return settings.HEALTH_UNHEALTHY
+            else:
+                return settings.HEALTH_WITHERED
+        elif resource_name == settings.RESOURCE_EARTH:
+            if level >= settings.EARTH_HEALTH_THRESHOLD:
+                return settings.HEALTH_HEALTHY
+            elif level >= settings.EARTH_UNHEALTHY_THRESHOLD:
+                return settings.HEALTH_UNHEALTHY
+            else:
+                return settings.HEALTH_WITHERED
+        else: # Default for sun.
+            return settings.HEALTH_HEALTHY
+    
+    @staticmethod
+    def _has_crossed_threshold(old_value: int, new_value: int, resource_name: str) -> Optional[str]:
+        """
+        Check if a resource level change has crossed a threshold boundary.
+        
+        Args:
+            old_value: Previous resource level
+            new_value: New resource level
+            resource_name: The resource type ('water', 'earth', 'sun')
+            
+        Returns:
+            str or None: The new threshold status if crossed, None if no threshold crossed
+        """
+        old_status = NotificationService._get_threshold_status(resource_name, old_value)
+        new_status = NotificationService._get_threshold_status(resource_name, new_value)
+        
+        # Only notify when health deteriorates (not when it improves)
+        if old_status != new_status and old_value > new_value:
+            return new_status
+        
+        return None
+    
+    @staticmethod
+    def _get_user_contact_email(username: str) -> Optional[str]:
+        """
+        Retrieve the contact email for a user.
+        
+        Args:
+            username: The username to look up
+            
+        Returns:
+            str or None: The contact email if set, None otherwise
+        """
+        student_details = get_student_details(username)
+        if student_details:
+            return student_details.get('contactEmail')
+        return None
+    
+    @staticmethod
+    def _create_threshold_event(resource_name: str, threshold_status: str, new_level: int) -> Event:
+        """
+        Create an Event object for a threshold crossing notification and store it in the database.
+        
+        Args:
+            resource_name: The resource that crossed a threshold
+            threshold_status: The new health status ('Unhealthy' or 'Withered')
+            new_level: The current resource level
+            
+        Returns:
+            Event: Event object describing the threshold crossing
+            
+        Raises:
+            Exception: If database insertion fails (logged but not re-raised)
+        """
+        # Map resource name to proper case
+        resource_display = resource_name.capitalize()
+        
+        # Create descriptive message based on status
+        if threshold_status == settings.HEALTH_WITHERED:
+            description = f"CRITICAL: Your tree's {resource_display} level has fallen to {new_level}% - it is now {threshold_status}! "
+            event_type = settings.EVENT_CHANGE
+        elif threshold_status == settings.HEALTH_UNHEALTHY:
+            description = f"WARNING: Your tree's {resource_display} level has fallen to {new_level}% - it is becoming {threshold_status}. "
+            event_type = settings.EVENT_CHANGE
+        else:
+            # This should not be reached in normal operation, but serves as a defensive fallback
+            description = f"An error occurred while processing the threshold event. Contact the Bristlecone team for support. "
+            event_type = settings.EVENT_CHANGE
+        
+        event = Event(
+            eventID=str(uuid.uuid4()),
+            eventType=event_type,
+            resourceAffected=resource_display,
+            description=description,
+            percentChange=0,  # Just describing absolute threshold
+            conditions=f"{resource_display} level fell below threshold into {threshold_status} status"
+        )
+        
+        # Store event in database
+        try:
+            add_event(event)
+        except Exception as e:
+            # Log but don't fail notification if database insertion fails
+            print(f"Warning: Failed to store threshold event in database: {e}")
+        
+        return event
+    
+    @staticmethod
+    def check_and_notify_threshold(username: str, tree_id: str, resource_name: str, 
+                                   old_value: int, new_value: int) -> bool:
+        """
+        Check if a threshold was crossed and send notification email if needed.
+        
+        This is the main entry point for threshold-based notifications. It should be
+        called after any resource update to check if a notification is warranted.
+        
+        Args:
+            username: The owner of the tree
+            tree_id: The tree ID being monitored
+            resource_name: The resource that was updated ('water', 'earth', 'sun')
+            old_value: The previous resource level
+            new_value: The new resource level
+            
+        Returns:
+            bool: True if notification was sent, False otherwise
+        """
+        # Check if we crossed a threshold
+        threshold_status = NotificationService._has_crossed_threshold(
+            old_value, new_value, resource_name
+        )
+        
+        if not threshold_status:
+            return False  # No threshold crossed
+        
+        # Get user's contact email
+        contact_email = NotificationService._get_user_contact_email(username)
+        
+        if not contact_email:
+            print(f"No contact email found for user {username} - skipping notification")
+            return False
+        
+        # Create event for the threshold crossing
+        event = NotificationService._create_threshold_event(
+            resource_name, threshold_status, new_value
+        )
+        
+        # Send notification
+        try:
+            success = EmailService.send_event_notification(contact_email, event)
+            if success:
+                print(f"Threshold notification sent to {username} ({contact_email}) for {resource_name} -> {threshold_status}")
+            return success
+        except Exception as e:
+            print(f"Error sending threshold notification to {username}: {e}")
+            return False

--- a/server/services/tree_service.py
+++ b/server/services/tree_service.py
@@ -1,7 +1,9 @@
 """Tree management service."""
 from typing import Optional, Dict
-from database.getItemsFromDatabase import get_tree, get_all_trees
+from database.getItemsFromDatabase import get_tree, get_all_trees, _query
 from database.addItemsToDatabase import update_stat, apply_passive_decay
+from services.notification_service import NotificationService
+from config.settings import settings
 
 
 class TreeService:
@@ -10,6 +12,50 @@ class TreeService:
     updating resource stats, and applying passive decay mechanics.
     """
     
+    @staticmethod
+    def _get_tree_resource_snapshot(tree_id: str) -> Optional[Dict]:
+        """
+        Fetch owner and current resource levels for a tree.
+
+        Returns:
+            Dict with ownerUsername/water/earth/sun or None if tree missing.
+        """
+        return _query(
+            """SELECT t.ownerUsername, r.water, r.earth, r.sun
+               FROM Tree t
+               LEFT JOIN TreeResources r ON t.treeID = r.treeID
+               WHERE t.treeID = ?""",
+            (tree_id,),
+            fetchone=True,
+        )
+
+    @staticmethod
+    def _notify_resource_changes(tree_id: str, before: Dict, after: Dict) -> None:
+        """
+        Send threshold notifications for any changed resource levels.
+        """
+        username = after.get("ownerUsername") or before.get("ownerUsername")
+        if not username:
+            return
+
+        for resource_name in (settings.RESOURCE_WATER, settings.RESOURCE_EARTH, settings.RESOURCE_SUN):
+            old_value = before.get(resource_name) or 0
+            new_value = after.get(resource_name) or 0
+
+            if old_value == new_value:
+                continue
+
+            try:
+                NotificationService.check_and_notify_threshold(
+                    username=username,
+                    tree_id=tree_id,
+                    resource_name=resource_name,
+                    old_value=old_value,
+                    new_value=new_value,
+                )
+            except Exception as e:
+                print(f"Error checking threshold notification for tree {tree_id} ({resource_name}): {e}")
+
     @staticmethod
     def get_user_tree(username: str) -> Optional[Dict]:
         """
@@ -62,11 +108,21 @@ class TreeService:
 
         Note: Valid stat_name values are defined in settings.py
         """
+        before = TreeService._get_tree_resource_snapshot(tree_id)
         update_stat(tree_id, stat_name, value)
+        after = TreeService._get_tree_resource_snapshot(tree_id)
+
+        if before and after:
+            TreeService._notify_resource_changes(tree_id, before, after)
     
     @staticmethod
     def apply_decay(tree_id: str) -> None:
-        apply_passive_decay(tree_id)
+        before = TreeService._get_tree_resource_snapshot(tree_id)
+        decayed = apply_passive_decay(tree_id)
+        after = TreeService._get_tree_resource_snapshot(tree_id)
+
+        if decayed and before and after:
+            TreeService._notify_resource_changes(tree_id, before, after)
     
     @staticmethod
     def apply_decay_to_all() -> int:
@@ -87,7 +143,7 @@ class TreeService:
         for tree_row in all_trees:
             try:
                 tree_id = tree_row['treeID']
-                apply_passive_decay(tree_id)
+                TreeService.apply_decay(tree_id)
                 count += 1
             except Exception as e:
                 print(f"Error applying decay to tree {tree_row.get('treeID')}: {e}")
@@ -113,6 +169,6 @@ class TreeService:
         """
         tree = get_tree(username)
         if tree:
-            apply_passive_decay(tree['treeID'])
+            TreeService.apply_decay(tree['treeID'])
             tree = get_tree(username)  # Refresh after decay
         return tree

--- a/server/utils/email.py
+++ b/server/utils/email.py
@@ -75,7 +75,7 @@ class EmailService:
         event_str = (
             f"Event Type: {event_data['eventType']}, "
             f"Resource Affected: {event_data['resourceAffected']}, "
-            f"Description: {event_data['description']}, "
+            f"Description: {event_data['description']} "
             f"Stat Changes: {event_data['percentChange']}%, "
             f"Conditions Met: {event_data['conditions']}"
         )


### PR DESCRIPTION
## What:
- Email notifications to contactEmail after tree falls under threshold.
- Event logging to database upon reaching threshold.

## Why:
- Keep users informed when their tree is dying.

## Checklist
- [ ] Passes all tests
- [ ] Change Decay Rate to .1 or something super fast; ensure that it sends all emails for thresholds (defined in settings.py).
- [ ] Ensure all other functionality works.
- [ ] Try changing contact email and verify it emails correct email.

NOTE:  Emails may be sent to spam.